### PR TITLE
style(markdown): enforce one paragraph per line

### DIFF
--- a/.claude/skills/profile-portfolio/SKILL.md
+++ b/.claude/skills/profile-portfolio/SKILL.md
@@ -14,11 +14,7 @@ description: >-
 
 # Profile / Portfolio landing page
 
-This site (`bamr87.github.io`) is the user's profile + portfolio landing page. The
-showcase of their GitHub work is **data-driven**: a curated registry plus live
-GitHub metadata, rendered into two surfaces by one generator. Editing the rendered
-output by hand is a dead end — it gets overwritten on the next run. Always change
-the source and regenerate.
+This site (`bamr87.github.io`) is the user's profile + portfolio landing page. The showcase of their GitHub work is **data-driven**: a curated registry plus live GitHub metadata, rendered into two surfaces by one generator. Editing the rendered output by hand is a dead end — it gets overwritten on the next run. Always change the source and regenerate.
 
 ## The pipeline at a glance
 
@@ -27,12 +23,9 @@ _data/projects.yml   →   scripts/generate_portfolio.py   →   pages/_about/po
 (curated registry)       (fetches live GitHub metadata)  →   README.md  AUTO:portfolio span     (featured table on homepage)
 ```
 
-`README.md` is the site homepage (`permalink: /`), so the featured table appears on
-the landing page; the full grouped showcase lives at `/about/portfolio/`.
+`README.md` is the site homepage (`permalink: /`), so the featured table appears on the landing page; the full grouped showcase lives at `/about/portfolio/`.
 
-This is the sibling of `scripts/generate_features_index.py` (which aggregates
-*feature* metadata across repos). Same philosophy: a registry + the GitHub API +
-deterministic, committable output.
+This is the sibling of `scripts/generate_features_index.py` (which aggregates *feature* metadata across repos). Same philosophy: a registry + the GitHub API + deterministic, committable output.
 
 ## The registry: `_data/projects.yml`
 
@@ -49,21 +42,15 @@ projects:
     blurb: "..."         # optional — overrides the GitHub description when it's weak/empty
 ```
 
-Only `repo` is required. Everything else (stars, language, homepage/Pages URL,
-topics, license, last commit) is fetched live from GitHub at generation time, so the
-registry stays small and the page stays current without manual edits.
+Only `repo` is required. Everything else (stars, language, homepage/Pages URL, topics, license, last commit) is fetched live from GitHub at generation time, so the registry stays small and the page stays current without manual edits.
 
 ## Common tasks
 
-**Add or feature a project** — append (or move) an entry in `_data/projects.yml`,
-set `featured:`/`category:`/`blurb:` as desired, then regenerate. Put featured
-projects where you want them in the homepage table; order matters.
+**Add or feature a project** — append (or move) an entry in `_data/projects.yml`, set `featured:`/`category:`/`blurb:` as desired, then regenerate. Put featured projects where you want them in the homepage table; order matters.
 
-**Remove a project from the showcase** — delete its entry, or add it to `exclude:`
-if it keeps reappearing from some auto-source.
+**Remove a project from the showcase** — delete its entry, or add it to `exclude:` if it keeps reappearing from some auto-source.
 
-**Refresh metadata** (stars/descriptions/links changed upstream) — just rerun the
-generator; no registry edit needed.
+**Refresh metadata** (stars/descriptions/links changed upstream) — just rerun the generator; no registry edit needed.
 
 **Regenerate:**
 ```bash
@@ -71,18 +58,12 @@ python3 scripts/generate_portfolio.py          # writes only what actually chang
 python3 scripts/generate_portfolio.py --check  # CI drift gate: exit 1 if output is stale
 ```
 
-The generator resolves a GitHub token from `--token`, then `FEATURES_GITHUB_TOKEN`/
-`GITHUB_TOKEN`/`GH_TOKEN`, then `gh auth token`. Public repos work without a token but
-share a low unauthenticated rate limit, so a token is preferred. Output is
-deterministic and timestamp-stable — a rerun with no upstream changes writes nothing,
-which keeps diffs and CI clean.
+The generator resolves a GitHub token from `--token`, then `FEATURES_GITHUB_TOKEN`/ `GITHUB_TOKEN`/`GH_TOKEN`, then `gh auth token`. Public repos work without a token but share a low unauthenticated rate limit, so a token is preferred. Output is deterministic and timestamp-stable — a rerun with no upstream changes writes nothing, which keeps diffs and CI clean.
 
 ## Conventions to preserve
 
 - **Don't hand-edit** `pages/_about/portfolio/index.md` or the
-  `<!-- AUTO:portfolio:start -->…<!-- AUTO:portfolio:end -->` span in `README.md`.
-  Both carry a "generated — edit the registry instead" banner. Change
-  `_data/projects.yml` and regenerate.
+`<!-- AUTO:portfolio:start -->…<!-- AUTO:portfolio:end -->` span in `README.md`. Both carry a "generated — edit the registry instead" banner. Change `_data/projects.yml` and regenerate.
 - A repo that fails to fetch (network off, renamed, private) renders from registry
   data alone and logs a warning — fix the `repo:` name if you see a 404 warning.
 - After regenerating, review the diff, then commit registry + generated files
@@ -92,9 +73,4 @@ which keeps diffs and CI clean.
 
 ## Why this design
 
-The user wants the site to be the definitive, low-maintenance showcase of their
-work. A hand-maintained project list rots — stars go stale, links break, new repos
-never get added. By curating *intent* (which repos, in what order, how described) in
-a tiny YAML file and pulling *facts* (stars, language, live URL) from GitHub on every
-build, the page stays accurate with near-zero upkeep, and the homepage + portfolio
-page can never disagree because one generator writes both.
+The user wants the site to be the definitive, low-maintenance showcase of their work. A hand-maintained project list rots — stars go stale, links break, new repos never get added. By curating *intent* (which repos, in what order, how described) in a tiny YAML file and pulling *facts* (stars, language, live URL) from GitHub on every build, the page stays accurate with near-zero upkeep, and the homepage + portfolio page can never disagree because one generator writes both.

--- a/.github/workflows/markdown-oneline.yml
+++ b/.github/workflows/markdown-oneline.yml
@@ -1,0 +1,36 @@
+# Seeded by the bamr87 hub (tools/fanout.sh --kit prose). Enforces the house
+# rule "one paragraph per line" in markdown: fails if any tracked *.md has
+# soft-wrapped prose. This is the Liquid-safe surgical unwrapper — it only joins
+# wrapped prose and leaves Liquid/HTML/tables/code/front-matter untouched.
+#
+# Fix locally:  python3 tools/unwrap-prose.py --write
+name: markdown-oneline
+
+on:
+  pull_request:
+    paths: ["**/*.md", "**/*.markdown"]
+  push:
+    branches: [main]
+    paths: ["**/*.md", "**/*.markdown"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: markdown-oneline-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oneline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Check one paragraph per line
+        run: |
+          python3 tools/unwrap-prose.py --check \
+            --exclude '(^|/)SCHEMA\.md$' --exclude '(^|/)CHANGELOG\.md$' \
+          || { echo "::error::Wrapped markdown prose found. Run: python3 tools/unwrap-prose.py --write"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ lastmod: 2025-11-11T00:00:00.000Z
 With over 10 years of battling the dark forces of accounting systems (e.g., QAD, OneStream, Infor, Oracle) for multi-national manufacturing empires, I have conjured deep insight and understanding of complex IT architectures that weave business operations with financial sorcery, designed to scale like a dragon's hoard.
 
 <!-- Simple GitHub badges for quick view -->
-[![Followers](https://img.shields.io/github/followers/bamr87?label=Followers&style=flat-square)](https://github.com/bamr87)
-[![Repo Stars](https://img.shields.io/github/stars/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io/stargazers)
-[![Top Language](https://img.shields.io/github/languages/top/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io)
-[![License](https://img.shields.io/github/license/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io/blob/main/LICENSE)
-[![Last Commit](https://img.shields.io/github/last-commit/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io/commits/main)
+[![Followers](https://img.shields.io/github/followers/bamr87?label=Followers&style=flat-square)](https://github.com/bamr87) [![Repo Stars](https://img.shields.io/github/stars/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io/stargazers) [![Top Language](https://img.shields.io/github/languages/top/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io) [![License](https://img.shields.io/github/license/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io/blob/main/LICENSE) [![Last Commit](https://img.shields.io/github/last-commit/bamr87/bamr87.github.io?style=flat-square)](https://github.com/bamr87/bamr87.github.io/commits/main)
 
 
 Throughout these epic quests, I have aided many manufacturing realms as they embark on perilous journeys into system upgrades, cloud migrations, and ERP modernizations, with some even dabbling in the arcane arts (ML, Git, DevOps). This exposure from a financial system perspective during my career is continuously refined by my master's degree in information systems and bachelor's in finance, bestowed upon me by the ancient scholars.
@@ -39,8 +35,7 @@ This repository serves double-duty: my personal profile/CV and a central dashboa
 > Badges are created with Shields.io and GitHub. Some badges depend on CI or releases; where a workflow or release is not configured the badge may show `unknown`.
 
 ### Quick Stats & Profile
-![Followers](https://img.shields.io/github/followers/bamr87?style=social)
-![Repo Count](https://img.shields.io/github/repo-size/bamr87/bamr87.github.io?label=Profile+Repo&style=flat-square)
+![Followers](https://img.shields.io/github/followers/bamr87?style=social) ![Repo Count](https://img.shields.io/github/repo-size/bamr87/bamr87.github.io?label=Profile+Repo&style=flat-square)
 
 ### Featured Projects
 <!-- AUTO:portfolio:start -->

--- a/pages/_about/contribute/contributors/bamr87/README.md
+++ b/pages/_about/contribute/contributors/bamr87/README.md
@@ -21,9 +21,7 @@ Here's some of my progress:
 [![roadmap.sh](https://api.roadmap.sh/v1-badge/wide/6553d32668ca6026132e78a8?variant=dark)](https://roadmap.sh/u/bamr87)
 
 <!---
-bamr87/bamr87 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+bamr87/bamr87 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile. You can click the Preview link to take a look at your changes. --->
 
 <summary>Add this repo as a sub-tree</summary>
 <details>

--- a/pages/_about/features/jekyll.md
+++ b/pages/_about/features/jekyll.md
@@ -10,8 +10,7 @@ draft: draft
 {% raw %}
 [Cheatsheet](https://learn-the-web.algonquindesign.ca/topics/jekyll-cheat-sheet/)
 
-Setup and use
-Installation
+Setup and use Installation
 
 All these commands should be executed in Terminal, one-by-one, in order.
 
@@ -24,8 +23,7 @@ echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.bash_profile
 
 Then open your repo in Terminal, from GitHub Desktop: Repository > Open in Terminal
 
-bundle init
-Open the new Gemfile, add the following line:
+bundle init Open the new Gemfile, add the following line:
 
 ```bash
 gem "jekyll"
@@ -51,12 +49,9 @@ bundle exec jekyll serve
 
 View your website in a browser:
 
-'http://localhost:4000/'
-Stop Jekyll:
+'http://localhost:4000/' Stop Jekyll:
 
-Control + C
-Or just quit Terminal.
-☛ Jekyll terminal guide.
+Control + C Or just quit Terminal. ☛ Jekyll terminal guide.
 
 If hosting on GitHub, don’t forget baseurl
 
@@ -72,8 +67,7 @@ permalink: pretty
 
 ## Add the baseurl if hosting on GitHub
 
-baseurl: /your-folder-on-github
-Sample folder setup:
+baseurl: /your-folder-on-github Sample folder setup:
 
 ```bash
 _config.yml
@@ -94,8 +88,7 @@ index.html
 meat-eaters.html
 ```
 
-Files & paths
-Linking pages
+Files & paths Linking pages
 
 With permalink: pretty turned on the .html extension can be left off URLs.
 
@@ -137,11 +130,9 @@ Or for GitHub Pages folder hosting:
 <img src="{{site.baseurl}}/images/trex.jpg" alt="">
 ```
 
-Layouts
-Common header & footer
+Layouts Common header & footer
 
-First create a new file inside the _layouts folder, name it whatever you want. Inside that file put the common
-HTML.
+First create a new file inside the _layouts folder, name it whatever you want. Inside that file put the common HTML.
 
 `Use {{content}} as the placeholder for the HTML from each page.`
 
@@ -430,23 +421,13 @@ Usage:
 
   jekyll <subcommand> [options]
 
-Options:
-  -s, --source [DIR]  Source directory (defaults to ./)
-  -d, --destination [DIR]  Destination directory (defaults to ./_site)
+Options: -s, --source [DIR]  Source directory (defaults to ./) -d, --destination [DIR]  Destination directory (defaults to ./_site)
       --safe         Safe mode (defaults to false)
   -p, --plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]  Plugins directory (defaults to ./_plugins)
       --layouts DIR  Layouts directory (defaults to ./_layouts)
-  -h, --help         Show this message
-  -v, --version      Print the name and version
-  -t, --trace        Show the full backtrace when an error occurs
+-h, --help         Show this message -v, --version      Print the name and version -t, --trace        Show the full backtrace when an error occurs
 
-Subcommands:
-  serve, server, s      Serve your site locally
-  docs                  Launch local server with docs for Jekyll v2.5.3
-  build, b              Build your site
-  doctor, hyde          Search site and print specific deprecation warnings
-  new                   Creates a new Jekyll site scaffold in PATH
-  help                  Show the help message, optionally for a given subcommand.
+Subcommands: serve, server, s      Serve your site locally docs                  Launch local server with docs for Jekyll v2.5.3 build, b              Build your site doctor, hyde          Search site and print specific deprecation warnings new                   Creates a new Jekyll site scaffold in PATH help                  Show the help message, optionally for a given subcommand.
 ```
 
 ### `build` Command
@@ -470,8 +451,7 @@ Options:
   -D, --drafts       Render posts in the _drafts folder
       --unpublished  Render posts that were marked as unpublished
 
-  -q, --quiet        Silence output.
-  -V, --verbose      Print verbose output.
+-q, --quiet        Silence output. -V, --verbose      Print verbose output.
 ```
 
 ### `serve` Command
@@ -565,9 +545,7 @@ or result in (with `permalink: /:title.html`):
     └── index.html                  # index page
 ```
 
-Note: See the `jekyll-minimal-theme` starter kit for an example
-[source repo](https://github.com/feedreader/jekyll-minimal-theme) and
-[live demo](http://feedreader.github.io/jekyll-minimal-theme).
+Note: See the `jekyll-minimal-theme` starter kit for an example [source repo](https://github.com/feedreader/jekyll-minimal-theme) and [live demo](http://feedreader.github.io/jekyll-minimal-theme).
 
 With post drafts, page collections, data stores and shared building blocks:
 
@@ -599,15 +577,11 @@ With post drafts, page collections, data stores and shared building blocks:
 └── index.html                         # site index template
 ```
 
-Note: The `_post`, `_drafts`, `_layouts`, `_includes`, `_data`, `_books`, `_site` folders must start
-with an underscore (`_`).
+Note: The `_post`, `_drafts`, `_layouts`, `_includes`, `_data`, `_books`, `_site` folders must start with an underscore (`_`).
 
 ## `_posts` Folder
 
-The post file name must follow the format: _YEAR-MONTH-DAY-TITLE.MARKUP_
-(e.g. `2015-01-15-week-3-slideshow.md`).
-The permalinks can be customized for each post,
-but the date and markup language are determined by the file name.
+The post file name must follow the format: _YEAR-MONTH-DAY-TITLE.MARKUP_ (e.g. `2015-01-15-week-3-slideshow.md`). The permalinks can be customized for each post, but the date and markup language are determined by the file name.
 
 ```
 ├── _posts             
@@ -711,10 +685,7 @@ site.tags.TAG              -- The list of all Posts with tag TAG.
 
 **Your Own (Custom)**
 
-All variables set via the command line and 
-in your `_config.yml`  site configuration are available through the `site` variable.
-For example, if you have `url: http://openfootball.github.io` in your configuration file,
-then in your Posts and Pages it will be stored in `site.url`.
+All variables set via the command line and in your `_config.yml`  site configuration are available through the `site` variable. For example, if you have `url: http://openfootball.github.io` in your configuration file, then in your Posts and Pages it will be stored in `site.url`.
 
 If you add in your `_config.yml` site configuration, for example:
 
@@ -730,8 +701,7 @@ site.url     -- your site's url
 site.title   -- your site's title
 ```
 
-Note: Jekyll does not parse changes to `_config.yml` in watch mode,
-you must restart Jekyll to see changes to variables.
+Note: Jekyll does not parse changes to `_config.yml` in watch mode, you must restart Jekyll to see changes to variables.
 
 
 ## Page Variables
@@ -1009,9 +979,7 @@ page.previous     --  The previous post relative to the position of the current 
 ```
 {% raw %}
 {% highlight ruby %}
-def main
-  puts 'Hello World'
-end
+def main puts 'Hello World' end
 {% endhighlight %}
 {% endraw %}
 
@@ -1019,9 +987,7 @@ end
 
 ```
 {% highlight ruby linenos %}         -- Use line numbers
-def main
-  puts 'Hello World'
-end
+def main puts 'Hello World' end
 {% endhighlight %}
 ```
 
@@ -1036,14 +1002,7 @@ The default `date` permalink is defined as:
 ### Permalink Variables
 
 ```
-year        -- Year from the Post’s filename
-month       -- Month from the Post’s filename
-i_month     -- Month from the Post’s filename without leading zeros.
-day         -- Day from the Post’s filename
-i_day       -- Day from the Post’s filename without leading zeros.
-short_year  -- Year from the Post’s filename without the century.
-title       -- Title from the Post’s filename
-categories  -- The specified categories for this Post.
+year        -- Year from the Post’s filename month       -- Month from the Post’s filename i_month     -- Month from the Post’s filename without leading zeros. day         -- Day from the Post’s filename i_day       -- Day from the Post’s filename without leading zeros. short_year  -- Year from the Post’s filename without the century. title       -- Title from the Post’s filename categories  -- The specified categories for this Post.
                If a post has multiple categories, Jekyll will create a hierarchy
                (e.g. /category1/category2). Also Jekyll automatically parses out double slashes in the URLs,
                so if no categories are present, it will ignore this.
@@ -1054,9 +1013,7 @@ categories  -- The specified categories for this Post.
 **Built-in**
 
 ```
-date     /:categories/:year/:month/:day/:title.html
-pretty   /:categories/:year/:month/:day/:title/
-none     /:categories/:title.html
+date     /:categories/:year/:month/:day/:title.html pretty   /:categories/:year/:month/:day/:title/ none     /:categories/:title.html
 ```
 
 **Examples**
@@ -1064,10 +1021,7 @@ none     /:categories/:title.html
 Given a post named: /2015-01-15-week-3-slideshow.md
 
 ```
-None specified (date)             /2015/01/15/week-3-slideshow.html
-pretty                            /2015/01/15/week-3-slideshow/index.html
-/:month-:day-:year/:title.html    /01-15-2015/week-3-slideshow.html
-/blog/:year/:month/:day/:title    /blog/2015/01/15/week-3-slideshow/index.html
+None specified (date)             /2015/01/15/week-3-slideshow.html pretty                            /2015/01/15/week-3-slideshow/index.html /:month-:day-:year/:title.html    /01-15-2015/week-3-slideshow.html /blog/:year/:month/:day/:title    /blog/2015/01/15/week-3-slideshow/index.html
 ```
 
 
@@ -1075,8 +1029,7 @@ pretty                            /2015/01/15/week-3-slideshow/index.html
 
 
 ```
-├── _config.yml            # site configuration (add sass settings)
-└── css 
+├── _config.yml            # site configuration (add sass settings) └── css
     ├── _settings.scss     # include / partial settings
     └── style.scss         # main styles 
 ```
@@ -1092,8 +1045,7 @@ will result in:
 Example - `_config.yml`:
 
 ```
-sass:
-  sass_dir: css    # gets used for partial lookup (default is _sass)
+sass: sass_dir: css    # gets used for partial lookup (default is _sass)
 ```
 
 Example - `_settings.scss`:
@@ -1101,8 +1053,7 @@ Example - `_settings.scss`:
 ```
 $font-family:    Helvetica, Arial, sans-serif;
 
-$color-primary:  #8b0000;    // dark red (ruby)
-...
+$color-primary:  #8b0000;    // dark red (ruby) ...
 ```
 
 Exampe - `style.scss`:
@@ -1113,9 +1064,7 @@ Exampe - `style.scss`:
 
 @import 'settings';           // include partial (will use sass_dir for lookup)
 
-body {
-  font-family:  $font-family; // use variables, nested rules, and more
-}
+body { font-family:  $font-family; // use variables, nested rules, and more }
 ```
 
 ```yaml
@@ -1134,8 +1083,7 @@ or with comments
 ---
 ```
 
-required; ensures Jekyll converts `style.scss` to `style.css`; 
-include all partials (e.g. `_settings.scss`, and so on) with `@import` directives.
+required; ensures Jekyll converts `style.scss` to `style.css`; include all partials (e.g. `_settings.scss`, and so on) with `@import` directives.
 
 (Source: [jekyll-sass-converter gem](https://github.com/jekyll/jekyll-sass-converter))
 

--- a/pages/_about/profile/bamr87.md
+++ b/pages/_about/profile/bamr87.md
@@ -35,9 +35,7 @@ git subtree add --prefix=pages/_about/contributors/bamr87 bamr87 main
 
 <!-- Optionally, include the theme (if you don't want to struggle to write the CSS) -->
 <link
-  rel="stylesheet"
-  href="https://unpkg.com/github-calendar@latest/dist/github-calendar-responsive.css"
-/>
+rel="stylesheet" href="https://unpkg.com/github-calendar@latest/dist/github-calendar-responsive.css" />
 
 <!-- Prepare a container for your calendar. -->
 <div class="calendar">

--- a/pages/_about/purpose.md
+++ b/pages/_about/purpose.md
@@ -5,14 +5,7 @@ lastmod: 2024-05-11T22:54:10.783Z
 
 ## Statement of Purpose
 
-The comprehension of our universe is constantly morphed by the information available and what is considered to be true. 
-That truth is the core of humanity’s internal struggle and desire to find, whether it be in the form of religion or science. 
-Regardless of how the content in question is true or false, it is ultimately the individual who determines it. 
-As we all know in today’s information age, truth has become easily accessible through the advent of the internet but becoming harder and harder to find through the vastness of information. 
-Our society was not equipped to navigate through this sea of information and data, and the forces controlling this wealth are motivated by the capitalistic framework that drives our economy forward. 
-Big businesses and government institutions have failed to harness this information revolution for the greater good as we can see by the growing wealth gap, and diminishing educational standards. 
-I have been witnessing this trend towards greater economic disparity as information technology grows ever more important to the wellbeing of our society, 
-which is why I am passionate to advance the knowledge of Information Science in the area of info tech education to enable public empowerment.
+The comprehension of our universe is constantly morphed by the information available and what is considered to be true. That truth is the core of humanity’s internal struggle and desire to find, whether it be in the form of religion or science. Regardless of how the content in question is true or false, it is ultimately the individual who determines it. As we all know in today’s information age, truth has become easily accessible through the advent of the internet but becoming harder and harder to find through the vastness of information. Our society was not equipped to navigate through this sea of information and data, and the forces controlling this wealth are motivated by the capitalistic framework that drives our economy forward. Big businesses and government institutions have failed to harness this information revolution for the greater good as we can see by the growing wealth gap, and diminishing educational standards. I have been witnessing this trend towards greater economic disparity as information technology grows ever more important to the wellbeing of our society, which is why I am passionate to advance the knowledge of Information Science in the area of info tech education to enable public empowerment.
 
 ## Goals
 
@@ -50,8 +43,7 @@ Hooded Robin
 
 SEC Financial Data Analyzer
 
-**https://www.sec.gov/os/accessing-edgar-data**
-**[EDGAR Data API](https://www.sec.gov/os/accessing-edgar-data)**
+**https://www.sec.gov/os/accessing-edgar-data** **[EDGAR Data API](https://www.sec.gov/os/accessing-edgar-data)**
 
 Data Source
 

--- a/pages/_docs/jekyll/cannot-start-jekyll-at-specific-port.md
+++ b/pages/_docs/jekyll/cannot-start-jekyll-at-specific-port.md
@@ -70,8 +70,7 @@ sudo /etc/NX/nxserver --shutdown
 sudo /etc/NX/nxserver --startmode manual
 ```
 
-On Windows:
-Open the CMD console as administrator and move to the bin folder under the NoMachine installation directory and run:
+On Windows: Open the CMD console as administrator and move to the bin folder under the NoMachine installation directory and run:
 
 ```raw
 nxserver --shutdown

--- a/pages/_docs/jekyll/continuously-deploy-jekyll-website-to-gitHub-pages-with-travis-ci.md
+++ b/pages/_docs/jekyll/continuously-deploy-jekyll-website-to-gitHub-pages-with-travis-ci.md
@@ -25,8 +25,7 @@ Another approach is to use third-party service(eg. Travis CI) to display Jekyll 
 
 ## 3. Configuration of GitHub Page
 
-Add a file named `Gemfile` in the root of the GitHub Pages repository with the following content:
-Gemfile
+Add a file named `Gemfile` in the root of the GitHub Pages repository with the following content: Gemfile
 
 ```raw
 source 'https://rubygems.org'
@@ -47,41 +46,15 @@ Submit these two files to GitHub repository.
 
 ## 4. Configuration on Travis CI
 
-Access the home page of Travis CI - <https://travis-ci.org>, logon with your GitHub account.
-![image](/assets/images/jekyll/8141/travisci_account.png)
-All the public repositories will be displayed here. Find the Github Page repository and switch on for auto building. The only left thing to do is to make some changes to your repository. Travis CI starts building the website once it detects new changes are committed.
-![image](/assets/images/jekyll/8141/travisci_activate.png)
+Access the home page of Travis CI - <https://travis-ci.org>, logon with your GitHub account. ![image](/assets/images/jekyll/8141/travisci_account.png) All the public repositories will be displayed here. Find the Github Page repository and switch on for auto building. The only left thing to do is to make some changes to your repository. Travis CI starts building the website once it detects new changes are committed. ![image](/assets/images/jekyll/8141/travisci_activate.png)
 
 ## 5. Demo
 
-Edit some files and submit them to GitHub. Few minutes later, you will receive one notification email from GitHub Page saying the page build failed. However, there is no detailed information of the failure. We don't know what is the exact error.
-![image](/assets/images/jekyll/8141/notification_builderror.png)
-Then, you will get another notification email from Travis CI. It also reminds you that the build is failed.
-![image](/assets/images/jekyll/8141/notification_travis.png)
-Click on the 'Build was broken' link. You will see the details about the current build(which is numbered 86 in this example).
-![image](/assets/images/jekyll/8141/travis1.png)
-Scroll down until you see the error marked in red. The error comes from [Liquid](https://shopify.github.io/liquid/)(an open-source template language). It is complaining that the link to file '\_posts/2017-07-10-developing-ios-app.md' cannot be generated in '\_posts/2017-07-21-building-ios-app-with-xamarin.md'. The file 'developing-ios-app' doesn't exist.
-![image](/assets/images/jekyll/8141/travis2.png)
-Open file '\_posts/2017-07-21-building-ios-app-with-xamarin.md'. The cause is found. In the last commit, I changed the file name from 'developing-ios-app' to 'building-ios-app-with-xcode'. But I forgot to change the files which link to this file.
-![image](/assets/images/jekyll/8141/linkerror.png)
-Correct the file name in '\_posts/2017-07-21-building-ios-app-with-xamarin.md' and submit the change to Github. No notification email from Github, instead, only one notification email from Travis CI. The new build(#87) succeeded.
-![image](/assets/images/jekyll/8141/notification_fixed.png)
-Click on the 'Build was fixed' link. You will see the details about the latest build.
-![image](/assets/images/jekyll/8141/fix1.png)
-Scroll down, no error occurs this time.
-![image](/assets/images/jekyll/8141/fix2.png)
+Edit some files and submit them to GitHub. Few minutes later, you will receive one notification email from GitHub Page saying the page build failed. However, there is no detailed information of the failure. We don't know what is the exact error. ![image](/assets/images/jekyll/8141/notification_builderror.png) Then, you will get another notification email from Travis CI. It also reminds you that the build is failed. ![image](/assets/images/jekyll/8141/notification_travis.png) Click on the 'Build was broken' link. You will see the details about the current build(which is numbered 86 in this example). ![image](/assets/images/jekyll/8141/travis1.png) Scroll down until you see the error marked in red. The error comes from [Liquid](https://shopify.github.io/liquid/)(an open-source template language). It is complaining that the link to file '\_posts/2017-07-10-developing-ios-app.md' cannot be generated in '\_posts/2017-07-21-building-ios-app-with-xamarin.md'. The file 'developing-ios-app' doesn't exist. ![image](/assets/images/jekyll/8141/travis2.png) Open file '\_posts/2017-07-21-building-ios-app-with-xamarin.md'. The cause is found. In the last commit, I changed the file name from 'developing-ios-app' to 'building-ios-app-with-xcode'. But I forgot to change the files which link to this file. ![image](/assets/images/jekyll/8141/linkerror.png) Correct the file name in '\_posts/2017-07-21-building-ios-app-with-xamarin.md' and submit the change to Github. No notification email from Github, instead, only one notification email from Travis CI. The new build(#87) succeeded. ![image](/assets/images/jekyll/8141/notification_fixed.png) Click on the 'Build was fixed' link. You will see the details about the latest build. ![image](/assets/images/jekyll/8141/fix1.png) Scroll down, no error occurs this time. ![image](/assets/images/jekyll/8141/fix2.png)
 
 ## 6. Travis CI Dashboard
 
-The current activated repositories are listed in the dashboard.
-![image](/assets/images/jekyll/8141/dashboard.png)
-Click on the repository, we get the latest build.
-![image](/assets/images/jekyll/8141/latestbuild.png)
-Branches.
-![image](/assets/images/jekyll/8141/branches.png)
-Build history.
-![image](/assets/images/jekyll/8141/history.png)
-![image](/assets/images/jekyll/8141/history2.png)
+The current activated repositories are listed in the dashboard. ![image](/assets/images/jekyll/8141/dashboard.png) Click on the repository, we get the latest build. ![image](/assets/images/jekyll/8141/latestbuild.png) Branches. ![image](/assets/images/jekyll/8141/branches.png) Build history. ![image](/assets/images/jekyll/8141/history.png) ![image](/assets/images/jekyll/8141/history2.png)
 
 ## 7. Reference
 

--- a/pages/_docs/jekyll/deploying-jekyll-website-to-netlify.md
+++ b/pages/_docs/jekyll/deploying-jekyll-website-to-netlify.md
@@ -35,38 +35,15 @@ If you don't have netlify account yet, go to [Netlify](https://app.netlify.com/s
 
 ### 2.3 New Site from GitHub
 
-After login, you are in the app home page, click 'New site from Git'.
-![image](/assets/images/jekyll/8143/app.png)
-Choose 'Github', next.
-![image](/assets/images/jekyll/8143/newsite.png)
-Authorize Netlify to access your GitHub account, next.
-![image](/assets/images/jekyll/8143/authorize.png)
-Choose the repository '{{ site.github_user }}.github.io', next.
-![image](/assets/images/jekyll/8143/repository.png)
-Choose `master` for the Branch to deploy, set `jekyll build` to the Build command, and set `_site/` to the Publish directory, click the 'Deploy site' button.
-![image](/assets/images/jekyll/8143/options.png)
-Netlify will start to deploy your site.
-![image](/assets/images/jekyll/8143/inprogress.png)
-Switch to 'Deploy' tab to monitor the status and check the logs.
-![image](/assets/images/jekyll/8143/monitor.png)
-If no issue occurs, the publish will be done after few seconds(or minutes).
-![image](/assets/images/jekyll/8143/published.png)
+After login, you are in the app home page, click 'New site from Git'. ![image](/assets/images/jekyll/8143/app.png) Choose 'Github', next. ![image](/assets/images/jekyll/8143/newsite.png) Authorize Netlify to access your GitHub account, next. ![image](/assets/images/jekyll/8143/authorize.png) Choose the repository '{{ site.github_user }}.github.io', next. ![image](/assets/images/jekyll/8143/repository.png) Choose `master` for the Branch to deploy, set `jekyll build` to the Build command, and set `_site/` to the Publish directory, click the 'Deploy site' button. ![image](/assets/images/jekyll/8143/options.png) Netlify will start to deploy your site. ![image](/assets/images/jekyll/8143/inprogress.png) Switch to 'Deploy' tab to monitor the status and check the logs. ![image](/assets/images/jekyll/8143/monitor.png) If no issue occurs, the publish will be done after few seconds(or minutes). ![image](/assets/images/jekyll/8143/published.png)
 
 ### 2.4 Testing
 
-Click on the green link. Our app is now running in the domain of Netlify.
-![image](/assets/images/jekyll/8143/homepage.png)
-Try to switch other pages, all work fine.
-![image](/assets/images/jekyll/8143/portfolio.png)
+Click on the green link. Our app is now running in the domain of Netlify. ![image](/assets/images/jekyll/8143/homepage.png) Try to switch other pages, all work fine. ![image](/assets/images/jekyll/8143/portfolio.png)
 
 ### 2.5 Changing Site Name
 
-Switch to Settings tab, scroll down and click the 'Change site name' button.
-![image](/assets/images/jekyll/8143/settings.png)
-Change the name to '{{ site.github_user }}' and save.
-![image](/assets/images/jekyll/8143/changename.png)
-Access your site with the new URL, it should work.
-![image](/assets/images/jekyll/8143/newname.png)
+Switch to Settings tab, scroll down and click the 'Change site name' button. ![image](/assets/images/jekyll/8143/settings.png) Change the name to '{{ site.github_user }}' and save. ![image](/assets/images/jekyll/8143/changename.png) Access your site with the new URL, it should work. ![image](/assets/images/jekyll/8143/newname.png)
 
 ## 3. Reference
 

--- a/pages/_docs/jekyll/deploying-personal-website-with-custom-domain.md
+++ b/pages/_docs/jekyll/deploying-personal-website-with-custom-domain.md
@@ -19,12 +19,7 @@ For demo purpose, I will use the repository of my personal website, see <https:/
 
 ## 2. Register domain from Godaddy
 
-Visit <https://www.godaddy.com>, register account and search domains.
-![image](/assets/images/jekyll/8142/godaddy_searchdomain.png)
-Add the domain you're interested into shopping cart, and prepare to pay for it.
-![image](/assets/images/jekyll/8142/godaddy_cart.png)
-After you finish the payment, congratulations, you own the domain!
-![image](/assets/images/jekyll/8142/godaddy_domain.png)
+Visit <https://www.godaddy.com>, register account and search domains. ![image](/assets/images/jekyll/8142/godaddy_searchdomain.png) Add the domain you're interested into shopping cart, and prepare to pay for it. ![image](/assets/images/jekyll/8142/godaddy_cart.png) After you finish the payment, congratulations, you own the domain! ![image](/assets/images/jekyll/8142/godaddy_domain.png)
 
 ## 3. Setup DNS
 
@@ -35,18 +30,13 @@ Now, it's time to setup DNS for your new domain. Add `A` record to point the new
 * 185.199.110.153
 * 185.199.111.153
 
-In addition, add `CNAME` record to point the new domain(eg. {{ site.github_user }}.github.io) to the existing github page domain(eg. {{ site.github_user }}.github.io).
-![image](/assets/images/jekyll/8142/godaddy_adddns.png)
+In addition, add `CNAME` record to point the new domain(eg. {{ site.github_user }}.github.io) to the existing github page domain(eg. {{ site.github_user }}.github.io). ![image](/assets/images/jekyll/8142/godaddy_adddns.png)
 
 ## 4. Enable Custom Domain and SSL on GitHub
 
-Go to the github repository. In Settings, input the custom domain and check 'Enforce HTTPS'.
-![image](/assets/images/jekyll/8142/custom_domain.png){:width="700px"}
+Go to the github repository. In Settings, input the custom domain and check 'Enforce HTTPS'. ![image](/assets/images/jekyll/8142/custom_domain.png){:width="700px"}
 
-The settings on GitHub and GoDaddy will be activated after a while. Visit the website with new domain [{{ site.github_user }}.github.io]({{ site.github_user }}.github.io). Notice that the url always starts with `https`.
-![image](/assets/images/jekyll/8142/rongzhuang_home.png)
-Portfolio page.
-![image](/assets/images/jekyll/8142/rongzhuang_portfolio.png)
+The settings on GitHub and GoDaddy will be activated after a while. Visit the website with new domain [{{ site.github_user }}.github.io]({{ site.github_user }}.github.io). Notice that the url always starts with `https`. ![image](/assets/images/jekyll/8142/rongzhuang_home.png) Portfolio page. ![image](/assets/images/jekyll/8142/rongzhuang_portfolio.png)
 
 ## 5. Reference
 

--- a/pages/_docs/jekyll/index.md
+++ b/pages/_docs/jekyll/index.md
@@ -7,9 +7,7 @@ redirect_from:
   - /docs/jekyll/extras/
 lastmod: '2021-12-06T01:41:06.227Z'
 ---
-Jekyll is a static site generator. It takes text written in your
-favorite markup language and uses layouts to create a static website. You can
-tweak the site's look and feel, URLs, the data displayed on the page, and more. 
+Jekyll is a static site generator. It takes text written in your favorite markup language and uses layouts to create a static website. You can tweak the site's look and feel, URLs, the data displayed on the page, and more.
 
 ## Prerequisites
 
@@ -42,11 +40,9 @@ bundle exec jekyll serve
 ```
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
-{: .note .warning}
-If you are using Ruby version 3.0.0 or higher, step 5 [may fail](https://github.com/github/pages-gem/issues/752). You may fix it by adding `webrick` to your dependencies: `bundle add webrick`
+{: .note .warning} If you are using Ruby version 3.0.0 or higher, step 5 [may fail](https://github.com/github/pages-gem/issues/752). You may fix it by adding `webrick` to your dependencies: `bundle add webrick`
 
-{: .note .info}
-Pass the `--livereload` option to `serve` to automatically refresh the page with each change you make to the source files: `bundle exec jekyll serve --livereload`
+{: .note .info} Pass the `--livereload` option to `serve` to automatically refresh the page with each change you make to the source files: `bundle exec jekyll serve --livereload`
 
 
 If you encounter any errors during this process, check that you have installed all the prerequisites in [Requirements]({{ '/docs/installation/#requirements' | relative_url }}). 

--- a/pages/_docs/jekyll/jekyll-comments-with-disqus.md
+++ b/pages/_docs/jekyll/jekyll-comments-with-disqus.md
@@ -19,8 +19,7 @@ slug: jekyll-comments-disqus
 
 ### Registration
 
-Go to https://disqus.com/ to create a Disqus account. Login and go to settings->profile, set your name. This name will be used as short name for your site.
-![image](/assets/images/jekyll/8111/account.png)
+Go to https://disqus.com/ to create a Disqus account. Login and go to settings->profile, set your name. This name will be used as short name for your site. ![image](/assets/images/jekyll/8111/account.png)
 
 ### Universal Code
 Access the following link to find the universal code of your Disqus. Replace the shortname with yours.
@@ -94,8 +93,7 @@ key: tutorial
 ```
 {% endraw %}
 ### 2.4 Comments in Posting
-Open the page, you will see the comments.
-![image](/assets/images/jekyll/8111/comments.png)
+Open the page, you will see the comments. ![image](/assets/images/jekyll/8111/comments.png)
 
 ## 3. Displaying Comments Count
 ### 3.1 Script for Count
@@ -135,8 +133,7 @@ In the list page, it is added to all the links through 'tutorial.url'.
 
 ### Demo
 
-See the comments count is correctly displayed. Click on the link, it will navigate you to the comments on that page directly.
-![image](/assets/images/jekyll/8111/count.png)
+See the comments count is correctly displayed. Click on the link, it will navigate you to the comments on that page directly. ![image](/assets/images/jekyll/8111/count.png)
 
 ## References:
 

--- a/pages/_docs/jekyll/jekyll-config.md
+++ b/pages/_docs/jekyll/jekyll-config.md
@@ -30,13 +30,9 @@ The tables below list the available settings for Jekyll, and the various `option
 
 # Destination folders are cleaned on site builds
 
- The contents of `<destination>` are automatically
- cleaned, by default, when the site is built. Files or folders that are not
- created by your site will be removed. Some files could be retained
- by specifying them within the `<keep_files>` configuration directive.
+The contents of `<destination>` are automatically cleaned, by default, when the site is built. Files or folders that are not created by your site will be removed. Some files could be retained by specifying them within the `<keep_files>` configuration directive.
  
- Do not use an important location for `<destination>`; instead, use it as
- a staging area and copy files from there to your web server.
+Do not use an important location for `<destination>`; instead, use it as a staging area and copy files from there to your web server.
  
 # Build Command Options
 
@@ -65,9 +61,7 @@ The tables below list the available settings for Jekyll, and the various `option
 
 # Serve Command Options
 
-In addition to the options below, the `serve` sub-command can accept any of the options
-for the `build` sub-command, which are then applied to the site build which occurs right
-before your site is served.
+In addition to the options below, the `serve` sub-command can accept any of the options for the `build` sub-command, which are then applied to the site build which occurs right before your site is served.
 
 | Setting | Options and Flags |
 | --- | --- |
@@ -86,6 +80,5 @@ before your site is served.
 
 # Do not use tabs in configuration files
 
- This will either lead to parsing errors, or Jekyll will revert to the
- default settings. Use spaces instead.
+This will either lead to parsing errors, or Jekyll will revert to the default settings. Use spaces instead.
  

--- a/pages/_docs/jekyll/jekyll-highlighting.md
+++ b/pages/_docs/jekyll/jekyll-highlighting.md
@@ -93,8 +93,7 @@ table.hljs-ln td {
   padding-left: 10px !important;
 }
 ```
-The line numbers are displayed as follows.
-![image](/assets/images/jekyll/8123/line-numbers.png)
+The line numbers are displayed as follows. ![image](/assets/images/jekyll/8123/line-numbers.png)
 
 ### 2.4 Styles
 If you don't like the default style, you can change it with other styles. highlight.js supports 185 languages and 89 styles. Check all styles through the [demo page](https://highlightjs.org/static/demo/), then pick up your favorite one.
@@ -103,8 +102,7 @@ For example, I choose the style which is named `Atom One Light`. Concatenate all
 ```raw
 https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/styles/atom-one-light.min.css
 ```
-Replace the URL for the default style with the URL for the new style. Refresh the page to see the new style.
-![image](/assets/images/jekyll/8123/custom-style.png)
+Replace the URL for the default style with the URL for the new style. Refresh the page to see the new style. ![image](/assets/images/jekyll/8123/custom-style.png)
 
 ## 3. Reference
 * [Code highlighting in Jekyll blog using highlight.js](http://www.vishalsinha.in/2017/04/23/highlight-code-jekyll.html)

--- a/pages/_docs/jekyll/jekyll-liquid.md
+++ b/pages/_docs/jekyll/jekyll-liquid.md
@@ -42,8 +42,7 @@ is turned into a comment.
 Raw temporarily disables tag processing. This is useful for generating content (eg, Mustache, Handlebars) which uses conflicting syntax.  
 Input:  
 <div class="highlighter-rouge"><pre class="highlight"><code>&#123;&#37; raw &#37;&#125;
-  In Handlebars, {% raw %} {{ this }} {% endraw %}will be HTML-escaped, but {% raw %}{{{ that }}}{% endraw %} will not.
-&#123;&#37; endraw &#37;&#125;
+In Handlebars, {% raw %} {{ this }} {% endraw %}will be HTML-escaped, but {% raw %}{{{ that }}}{% endraw %} will not. &#123;&#37; endraw &#37;&#125;
 </code></pre>
 </div>
 Output:  

--- a/pages/_docs/jekyll/jekyll-pagination.md
+++ b/pages/_docs/jekyll/jekyll-pagination.md
@@ -60,10 +60,7 @@ Then, include it into template page `_layouts/tutorial.html`. The buttons are ad
 
 ### 2.3 Demo
 
-Open any posting page, we will see the buttons just below the title.
-![image](/assets/images/jekyll/8122/button-top.png){:width="700px"}
-And the same buttons in the bottom.
-![image](/assets/images/jekyll/8122/button-bottom.png){:width="700px"}
+Open any posting page, we will see the buttons just below the title. ![image](/assets/images/jekyll/8122/button-top.png){:width="700px"} And the same buttons in the bottom. ![image](/assets/images/jekyll/8122/button-bottom.png){:width="700px"}
 
 ## 3. Improvement
 

--- a/pages/_docs/jekyll/jekyll-progress-bar.md
+++ b/pages/_docs/jekyll/jekyll-progress-bar.md
@@ -78,8 +78,7 @@ Create nanobar with javascript and assign it to div with classname `nanobar`. No
 
 ### 2.6 Test
 
-Access any page, there is a green top bar below the navigation bar.
-![image](/assets/images/jekyll/8113/progress_bar.png)
+Access any page, there is a green top bar below the navigation bar. ![image](/assets/images/jekyll/8113/progress_bar.png)
 
 ## 3. Reference
 

--- a/pages/_docs/jekyll/jekyll-security.md
+++ b/pages/_docs/jekyll/jekyll-security.md
@@ -20,9 +20,7 @@ I have my personal website hosted on two domains, [{{ site.github_user }}.github
 
 ### 1.2 Header Security
 
-Visit [securityheaders.com](https://securityheaders.com) and scan headers for site https://{{ site.github_user }}.github.io.w
-![image](/assets/images/jekyll/8133/header_githubpages.png)
-All the checks on header are failed. If we scan site https://{{ site.github_user }}.netlify.com, same result will be returned.
+Visit [securityheaders.com](https://securityheaders.com) and scan headers for site https://{{ site.github_user }}.github.io.w ![image](/assets/images/jekyll/8133/header_githubpages.png) All the checks on header are failed. If we scan site https://{{ site.github_user }}.netlify.com, same result will be returned.
 
 ### 1.3 Resolution
 
@@ -51,8 +49,7 @@ In the root directory of repository, create a file named `netlify.toml` with the
       s-max-age=604800'''
 ```
 
-Submit this file, wait for a while to let Netlify deploy the change. Once this file is deployed, run the scan for https://{{ site.github_user }}.netlify.com. This time, we can see all tests for header security are passed.
-![image](/assets/images/jekyll/8133/header_netlify_fixed.png)
+Submit this file, wait for a while to let Netlify deploy the change. Once this file is deployed, run the scan for https://{{ site.github_user }}.netlify.com. This time, we can see all tests for header security are passed. ![image](/assets/images/jekyll/8133/header_netlify_fixed.png)
 
 ## 2. SSL
 

--- a/pages/_docs/jekyll/jekyll-social-share-buttons-with-sharethis.md
+++ b/pages/_docs/jekyll/jekyll-social-share-buttons-with-sharethis.md
@@ -18,15 +18,11 @@ The [ShareThis](https://www.sharethis.com/) button is an all-in-one widget that 
 ### 2.1 Registration
 Go to https://www.sharethis.com/ to create a new account.
 ### 2.2 Choose Button Type
-ShareThis provides two types of share button, inline buttons and sticky buttons. I choose sticky button for this tutorial.
-![image](/assets/images/jekyll/8118/buttontype.png)
+ShareThis provides two types of share button, inline buttons and sticky buttons. I choose sticky button for this tutorial. ![image](/assets/images/jekyll/8118/buttontype.png)
 ### 2.3 Button Design
-You can design the share buttons. Add or remove buttons based on your needs. Set the alignment, button labels, counts, etc.
-![image](/assets/images/jekyll/8118/buttondesign.png)
+You can design the share buttons. Add or remove buttons based on your needs. Set the alignment, button labels, counts, etc. ![image](/assets/images/jekyll/8118/buttondesign.png)
 ### 2.4 Scripts
-You will get the scripts.
-![image](/assets/images/jekyll/8118/scripts.png)
-Copy and add the scripts into `_layouts/default.html`.
+You will get the scripts. ![image](/assets/images/jekyll/8118/scripts.png) Copy and add the scripts into `_layouts/default.html`.
 ```html
 <script type='text/javascript' src='//platform-api.sharethis.com/js/sharethis.js#property=5b595ccbf5aa6d001130cf95&product=sticky-share-buttons' async='async'></script>
 ```
@@ -48,8 +44,7 @@ Access the website from mobile device.
 ![image](/assets/images/jekyll/8118/mobile_201.png){:width="400px"}  
 
 ## 5. Cross Domain
-ShareThis supports multiple domains. You can create different share buttons for different domains. For different domains, you will get different urls for sharethis.js.
-![image](/assets/images/jekyll/8118/multi-domain.png)
+ShareThis supports multiple domains. You can create different share buttons for different domains. For different domains, you will get different urls for sharethis.js. ![image](/assets/images/jekyll/8118/multi-domain.png)
 
 I deployed my personal website to two domains, https://{{ site.github_user }}.github.io/ and https://{{ site.github_user }}.github.io/. Both are generated based on the same codes, https://github.com/{{ site.github_user }}/{{ site.github_user }}.github.io.
 

--- a/pages/_docs/jekyll/jekyll-social-share-buttons.md
+++ b/pages/_docs/jekyll/jekyll-social-share-buttons.md
@@ -162,8 +162,7 @@ Include the share bar html file in the `_layouts/tutorial.html` template.
 {% endraw %}
 
 ## 4. Wrapping Up
-We see the share buttons below the pagination bar.
-![image](/assets/images/jekyll/8117/sharelinks.png)
+We see the share buttons below the pagination bar. ![image](/assets/images/jekyll/8117/sharelinks.png)
 
 ## 5. References:
 * [Social Media Share Bar for Jekyll blog/website](https://mycyberuniverse.com/web/social-media-share-bar-jekyll-blog-website.html)

--- a/pages/_docs/jekyll/jekyll-usage-and-customization.md
+++ b/pages/_docs/jekyll/jekyll-usage-and-customization.md
@@ -209,8 +209,7 @@ Open browser, access the favorite page.
 ![image](/assets/images/jekyll/8112/favorite.png)  
 
 ## 7. Collection
-Use `Collection` to create similar pages. The [portfolio index page](http://{{ site.github_user }}.github.io/portfolio/) is created by collection.
-Edit `_config.yml`, add following lines.
+Use `Collection` to create similar pages. The [portfolio index page](http://{{ site.github_user }}.github.io/portfolio/) is created by collection. Edit `_config.yml`, add following lines.
 ```
 collections:
   portfolio:
@@ -268,8 +267,7 @@ Same Package Sub-Class  | N       | Y       | Y         | Y
 Other Package Class     | N       | N       | N         | Y
 Other Package Sub-Class | N       | N       | Y         | Y
 ```
-The table in html looks like this.
-![image](/assets/images/jekyll/8112/table_markdown.png)
+The table in html looks like this. ![image](/assets/images/jekyll/8112/table_markdown.png)
 
 If we want to add class to html table, we can append class to the table in markdown, see sample below. Class `table-striped` is defined in Bootstrap 4, which is used to add zebra-stripes to a table.
 ```raw
@@ -333,13 +331,10 @@ Once the table is generated in html, it looks like this.
   </tbody>
 </table>
 ```
-Now, the table has striped rows.
-![image](/assets/images/jekyll/8112/table_striped.png)
+Now, the table has striped rows. ![image](/assets/images/jekyll/8112/table_striped.png)
 
 ## 9. Responsive Tables
-If table has many columns, some of them may be cut off in small screen.
-![image](/assets/images/jekyll/8112/table_partial.png){:width="450px"}
-One solution is to create a responsive table. We can embed the table into a div, which has the class `table-responsive-sm`. Class table-responsive-sm is defined in Bootstrap 4 for creating responsive tables.
+If table has many columns, some of them may be cut off in small screen. ![image](/assets/images/jekyll/8112/table_partial.png){:width="450px"} One solution is to create a responsive table. We can embed the table into a div, which has the class `table-responsive-sm`. Class table-responsive-sm is defined in Bootstrap 4 for creating responsive tables.
 ```raw
 <div class="table-responsive-sm" markdown="block">  
 
@@ -409,8 +404,7 @@ Once the table is generated in html, it looks like this.
 
 </div>
 ```
-One horizontal scrollbar is added to the table on screen.
-![image](/assets/images/jekyll/8112/table_scroll.png){:width="450px"}
+One horizontal scrollbar is added to the table on screen. ![image](/assets/images/jekyll/8112/table_scroll.png){:width="450px"}
 
 ## 10. References
 * [Official Jekyll Document](https://jekyllrb.com/docs/home/)

--- a/pages/_notes/Journal Entries/Github_s hidden gem.md
+++ b/pages/_notes/Journal Entries/Github_s hidden gem.md
@@ -7,8 +7,6 @@ longitude: -104.97393330
 altitude: 0.0000
 ---
 
-title: "github's hidden gem"
-description: 
-GPT Promt: 
+title: "github's hidden gem" description: GPT Promt:
 
 

--- a/pages/_notes/Journal Entries/What is my PiDentity_.md
+++ b/pages/_notes/Journal Entries/What is my PiDentity_.md
@@ -7,10 +7,4 @@ longitude: -104.97393330
 altitude: 0.0000
 ---
 
-What is my PiDentity?
-3.14[id] 
-userName:
-email:
-github:
-X:
-phone:
+What is my PiDentity? 3.14[id] userName: email: github: X: phone:

--- a/pages/_notes/cheetsheets/2022-10-07-powershell.md
+++ b/pages/_notes/cheetsheets/2022-10-07-powershell.md
@@ -15,14 +15,7 @@ draft: true
 lastmod: 2022-01-10T21:54:00.053Z
 ---
 
-Windows PowerShell is the successor of the windows cmd language, which itself has its roots in the ms-dos Bat language. All recent versions of Windows offer PowerShell (PS).
-PS may be seen as Microsoft's answer to the shells common in Unix/Linux (such as csh, bash, *etc.*). Its name implies that Microsoft sees the shell as powerful, which it arguably is.
-In these notes some important PS commands are listed and PowerShell's most notable feature, the object pipeline, is discussed. 
-From the outset it is important to note that, in contrast to Linux/Unix, *Windows PowerShell is completely case-insensitive.*
-The monospace text snippets below are valid PS and may be copied, pasted, and executed in a PowerShell- or a PowerShell_ISE-session. This is why the notes form a "Cheatsheet".
-As is common for cheatsheets, there is hardly any explanation, the examples speak for themselves. 
-It must be stressed here that many of the basic PS commands are not at all orthogonal, so that many variant pipelines can lead to the same effect. 
-Often an example is one out of a multitude of possibilities accomplishing the same task.
+Windows PowerShell is the successor of the windows cmd language, which itself has its roots in the ms-dos Bat language. All recent versions of Windows offer PowerShell (PS). PS may be seen as Microsoft's answer to the shells common in Unix/Linux (such as csh, bash, *etc.*). Its name implies that Microsoft sees the shell as powerful, which it arguably is. In these notes some important PS commands are listed and PowerShell's most notable feature, the object pipeline, is discussed. From the outset it is important to note that, in contrast to Linux/Unix, *Windows PowerShell is completely case-insensitive.* The monospace text snippets below are valid PS and may be copied, pasted, and executed in a PowerShell- or a PowerShell_ISE-session. This is why the notes form a "Cheatsheet". As is common for cheatsheets, there is hardly any explanation, the examples speak for themselves. It must be stressed here that many of the basic PS commands are not at all orthogonal, so that many variant pipelines can lead to the same effect. Often an example is one out of a multitude of possibilities accomplishing the same task.
 
 ## Contents
 - [## Unrelated to PS](#-unrelated-to-ps)
@@ -177,8 +170,7 @@ Get-ChildItem  -name       # Equivalent to (Get-ChildItem).name
 
 A PSDrive is a collection of entities that are grouped such that they may be accessed as a filesystem drive. The grouping is performed by a "PSprovider". By default a PS session has access to about a dozen PSdrives among which `c:, env:, alias:, HKLM:`.  Here `c:` is the usual Windows c-drive; `env:` is the space of Windows environmental variables; `alias:` is the collection of cmdlet aliases; `HKLM` is a hive in the Registry.
 
-Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows:
-Switch to env:
+Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows: Switch to env:
 
 ```powershell
 Set-Location env:                 # Prompt character becomes `Env:\>`
@@ -706,9 +698,7 @@ The cmdlet `rename-item` can take piped input for the old name and recognizes 
 ```
 gives the required change of the file extension.
 
-To change multiple names at once, one may use the `-replace` operator. Its syntax is:
-    ` string -replace regexp, new_name`
-In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
+To change multiple names at once, one may use the `-replace` operator. Its syntax is: ` string -replace regexp, new_name` In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
 
 ```
      'report.txt' -replace '\.txt$', '.doc'  # -> 'report.doc'
@@ -817,8 +807,7 @@ The last statement (`$assoc`) gives:
 15Strings
 =========
 
-**Strings** are as in PHP.
-'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
+**Strings** are as in PHP. 'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
 ```
       $five  = 5
       '3*$five'  -> 3*$five
@@ -826,15 +815,13 @@ The last statement (`$assoc`) gives:
       "$(3*5)" -> 15
 
 ```
-Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`.
-**Notes:**
+Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`. **Notes:**
 
 1.  `"`n"` gives the newline character.
 2.  The string `"John Doe"` can be appended to a file simply by `"John Doe" >> out.txt`. The file `out.txt` will be in UTF-16.
 3.  The cmdlet `add-content` (alias `ac`) writes to file by default in ANSI (Windows-1252), and allows specification of other encodings.
 
-**Here-strings**
-`@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
+**Here-strings** `@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
 
 Example, assume `$a -eq "Big Brother"`:
 ```
@@ -982,8 +969,7 @@ which returns the Windows environmental variable `path` with its entries stack
 17Comparison
 ============
 
-Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group.
-Examples:
+Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group. Examples:
 ```
     'peanutbutter' -like 'nut'         # false
     'peanutbutter' -like '*nut*'       # true   (* is wildcard)
@@ -1037,8 +1023,7 @@ PowerShell has built-in classes, one is `[console]` with methods (among others
     [console]::readkey()          # Return name of key + modifier(not under ISE)
 
 ```
-Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx).
-Examples:
+Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx). Examples:
 ```
     [math]::pi                    # 3.14159265358979
     [math]::cos([math]::pi)       # -1
@@ -1092,8 +1077,7 @@ For instance, suppress error message about inaccessible subdirectories as follow
 
 ```
 
-As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1).
-Example of trapping:
+As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1). Example of trapping:
 
 ```
     Trap [System.Exception] {
@@ -1126,8 +1110,7 @@ The global object `$error` is a stack containing the consecutive non-trapped e
 22Functions
 ===========
 
-A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs.
-To get the unique verbs of all (including user) functions sorted in alphabetical order:
+A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs. To get the unique verbs of all (including user) functions sorted in alphabetical order:
 ```
    gcm -commandtype function |select  verb -unique |sort verb|ft
 
@@ -1208,8 +1191,7 @@ Because the return array may be redirected to a file and not all console output 
    Write-Vars > foo.out # 'B', 'D' to console; 'A', 'E', 'C' to foo.out
 
 ```
-One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case.
-More examples:
+One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case. More examples:
 ```
    function list-txt{ls *.txt}
    $a = list-txt  # No console output, output of ls returned.
@@ -1381,8 +1363,7 @@ Now follows a list of examples that may be useful in inspecting/traversing the R
    ls   -rec -depth 1 -ea 4 | measure -line   # gives   804 lines
 
 ```
-while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`.
-**End note**
+while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`. **End note**
 
 The following command lists names of subkeys and subsubkeys of the present key together with an array containing the names of their value entries:
 ```
@@ -1554,8 +1535,7 @@ The names of members (methods and properties) of an object can be obtained by pi
 
 A PSDrive is a collection of entities that are grouped such that they may be accessed as a filesystem drive. The grouping is performed by a "PSprovider". By default a PS session has access to about a dozen PSdrives among which `c:, env:, alias:, HKLM:`.  Here `c:` is the usual Windows c-drive; `env:` is the space of Windows environmental variables; `alias:` is the collection of cmdlet aliases; `HKLM` is a hive in the Registry.
 
-Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows:
-Switch to env:
+Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows: Switch to env:
 
 ```
     Set-Location env:                 # Prompt character becomes `Env:\>`
@@ -2085,9 +2065,7 @@ The cmdlet `rename-item` can take piped input for the old name and recognizes 
 ```
 gives the required change of the file extension.
 
-To change multiple names at once, one may use the `-replace` operator. Its syntax is:
-    ` string -replace regexp, new_name`
-In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
+To change multiple names at once, one may use the `-replace` operator. Its syntax is: ` string -replace regexp, new_name` In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
 
 ```
      'report.txt' -replace '\.txt$', '.doc'  # -> 'report.doc'
@@ -2196,8 +2174,7 @@ The last statement (`$assoc`) gives:
 15Strings
 =========
 
-**Strings** are as in PHP.
-'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
+**Strings** are as in PHP. 'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
 ```
       $five  = 5
       '3*$five'  -> 3*$five
@@ -2205,15 +2182,13 @@ The last statement (`$assoc`) gives:
       "$(3*5)" -> 15
 
 ```
-Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`.
-**Notes:**
+Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`. **Notes:**
 
 1.  `"`n"` gives the newline character.
 2.  The string `"John Doe"` can be appended to a file simply by `"John Doe" >> out.txt`. The file `out.txt` will be in UTF-16.
 3.  The cmdlet `add-content` (alias `ac`) writes to file by default in ANSI (Windows-1252), and allows specification of other encodings.
 
-**Here-strings**
-`@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
+**Here-strings** `@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
 
 Example, assume `$a -eq "Big Brother"`:
 ```
@@ -2361,8 +2336,7 @@ which returns the Windows environmental variable `path` with its entries stack
 17Comparison
 ============
 
-Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group.
-Examples:
+Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group. Examples:
 ```
     'peanutbutter' -like 'nut'         # false
     'peanutbutter' -like '*nut*'       # true   (* is wildcard)
@@ -2416,8 +2390,7 @@ PowerShell has built-in classes, one is `[console]` with methods (among others
     [console]::readkey()          # Return name of key + modifier(not under ISE)
 
 ```
-Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx).
-Examples:
+Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx). Examples:
 ```
     [math]::pi                    # 3.14159265358979
     [math]::cos([math]::pi)       # -1
@@ -2471,8 +2444,7 @@ For instance, suppress error message about inaccessible subdirectories as follow
 
 ```
 
-As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1).
-Example of trapping:
+As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1). Example of trapping:
 
 ```
     Trap [System.Exception] {
@@ -2505,8 +2477,7 @@ The global object `$error` is a stack containing the consecutive non-trapped e
 22Functions
 ===========
 
-A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs.
-To get the unique verbs of all (including user) functions sorted in alphabetical order:
+A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs. To get the unique verbs of all (including user) functions sorted in alphabetical order:
 ```
    gcm -commandtype function |select  verb -unique |sort verb|ft
 
@@ -2587,8 +2558,7 @@ Because the return array may be redirected to a file and not all console output 
    Write-Vars > foo.out # 'B', 'D' to console; 'A', 'E', 'C' to foo.out
 
 ```
-One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case.
-More examples:
+One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case. More examples:
 ```
    function list-txt{ls *.txt}
    $a = list-txt  # No console output, output of ls returned.
@@ -2760,8 +2730,7 @@ Now follows a list of examples that may be useful in inspecting/traversing the R
    ls   -rec -depth 1 -ea 4 | measure -line   # gives   804 lines
 
 ```
-while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`.
-**End note**
+while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`. **End note**
 
 The following command lists names of subkeys and subsubkeys of the present key together with an array containing the names of their value entries:
 ```

--- a/pages/_notes/cheetsheets/Bash cheatsheet.md
+++ b/pages/_notes/cheetsheets/Bash cheatsheet.md
@@ -11,8 +11,7 @@ TODO: create a cheatsheet layout based on devhints.io
 lastmod: 2024-05-14T15:14:49.051Z
 ---
 
-Getting started
-{: .cols-3 }
+Getting started {: .cols-3 }
 
 ---------------
 

--- a/pages/_notes/cheetsheets/Shell and the CLI.md
+++ b/pages/_notes/cheetsheets/Shell and the CLI.md
@@ -50,9 +50,7 @@ cd github
 gh repo fork $gh_repo --clone=true --fork-name $gh_repo_dest
 ```
 
-wmic 
-/output:C:\Temp\list.txt product get name, version
-exit
+wmic /output:C:\Temp\list.txt product get name, version exit
 
 ```powershell
 

--- a/pages/_notes/cheetsheets/Windows Powershell Cheatsheet.md
+++ b/pages/_notes/cheetsheets/Windows Powershell Cheatsheet.md
@@ -8,14 +8,7 @@ tags:
   - powershell
 ---
 
-Windows PowerShell is the successor of the windows cmd language, which itself has its roots in the ms-dos Bat language. All recent versions of Windows offer PowerShell (PS).
-PS may be seen as Microsoft's answer to the shells common in Unix/Linux (such as csh, bash, *etc.*). Its name implies that Microsoft sees the shell as powerful, which it arguably is.
-In these notes some important PS commands are listed and PowerShell's most notable feature, the object pipeline, is discussed. 
-From the outset it is important to note that, in contrast to Linux/Unix, *Windows PowerShell is completely case-insensitive.*
-The monospace text snippets below are valid PS and may be copied, pasted, and executed in a PowerShell- or a PowerShell_ISE-session. This is why the notes form a "Cheatsheet".
-As is common for cheatsheets, there is hardly any explanation, the examples speak for themselves. 
-It must be stressed here that many of the basic PS commands are not at all orthogonal, so that many variant pipelines can lead to the same effect. 
-Often an example is one out of a multitude of possibilities accomplishing the same task.
+Windows PowerShell is the successor of the windows cmd language, which itself has its roots in the ms-dos Bat language. All recent versions of Windows offer PowerShell (PS). PS may be seen as Microsoft's answer to the shells common in Unix/Linux (such as csh, bash, *etc.*). Its name implies that Microsoft sees the shell as powerful, which it arguably is. In these notes some important PS commands are listed and PowerShell's most notable feature, the object pipeline, is discussed. From the outset it is important to note that, in contrast to Linux/Unix, *Windows PowerShell is completely case-insensitive.* The monospace text snippets below are valid PS and may be copied, pasted, and executed in a PowerShell- or a PowerShell_ISE-session. This is why the notes form a "Cheatsheet". As is common for cheatsheets, there is hardly any explanation, the examples speak for themselves. It must be stressed here that many of the basic PS commands are not at all orthogonal, so that many variant pipelines can lead to the same effect. Often an example is one out of a multitude of possibilities accomplishing the same task.
 
 ## Contents
 - [## Unrelated to PS](#-unrelated-to-ps)
@@ -170,8 +163,7 @@ Get-ChildItem  -name       # Equivalent to (Get-ChildItem).name
 
 A PSDrive is a collection of entities that are grouped such that they may be accessed as a filesystem drive. The grouping is performed by a "PSprovider". By default a PS session has access to about a dozen PSdrives among which `c:, env:, alias:, HKLM:`.  Here `c:` is the usual Windows c-drive; `env:` is the space of Windows environmental variables; `alias:` is the collection of cmdlet aliases; `HKLM` is a hive in the Registry.
 
-Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows:
-Switch to env:
+Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows: Switch to env:
 
 ```powershell
 Set-Location env:                 # Prompt character becomes `Env:\>`
@@ -699,9 +691,7 @@ The cmdlet `rename-item` can take piped input for the old name and recognizes 
 ```
 gives the required change of the file extension.
 
-To change multiple names at once, one may use the `-replace` operator. Its syntax is:
-    ` string -replace regexp, new_name`
-In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
+To change multiple names at once, one may use the `-replace` operator. Its syntax is: ` string -replace regexp, new_name` In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
 
 ```
      'report.txt' -replace '\.txt$', '.doc'  # -> 'report.doc'
@@ -810,8 +800,7 @@ The last statement (`$assoc`) gives:
 15Strings
 =========
 
-**Strings** are as in PHP.
-'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
+**Strings** are as in PHP. 'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
 ```
       $five  = 5
       '3*$five'  -> 3*$five
@@ -819,15 +808,13 @@ The last statement (`$assoc`) gives:
       "$(3*5)" -> 15
 
 ```
-Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`.
-**Notes:**
+Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`. **Notes:**
 
 1.  `"`n"` gives the newline character.
 2.  The string `"John Doe"` can be appended to a file simply by `"John Doe" >> out.txt`. The file `out.txt` will be in UTF-16.
 3.  The cmdlet `add-content` (alias `ac`) writes to file by default in ANSI (Windows-1252), and allows specification of other encodings.
 
-**Here-strings**
-`@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
+**Here-strings** `@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
 
 Example, assume `$a -eq "Big Brother"`:
 ```
@@ -975,8 +962,7 @@ which returns the Windows environmental variable `path` with its entries stack
 17Comparison
 ============
 
-Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group.
-Examples:
+Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group. Examples:
 ```
     'peanutbutter' -like 'nut'         # false
     'peanutbutter' -like '*nut*'       # true   (* is wildcard)
@@ -1030,8 +1016,7 @@ PowerShell has built-in classes, one is `[console]` with methods (among others
     [console]::readkey()          # Return name of key + modifier(not under ISE)
 
 ```
-Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx).
-Examples:
+Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx). Examples:
 ```
     [math]::pi                    # 3.14159265358979
     [math]::cos([math]::pi)       # -1
@@ -1085,8 +1070,7 @@ For instance, suppress error message about inaccessible subdirectories as follow
 
 ```
 
-As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1).
-Example of trapping:
+As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1). Example of trapping:
 
 ```
     Trap [System.Exception] {
@@ -1119,8 +1103,7 @@ The global object `$error` is a stack containing the consecutive non-trapped e
 22Functions
 ===========
 
-A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs.
-To get the unique verbs of all (including user) functions sorted in alphabetical order:
+A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs. To get the unique verbs of all (including user) functions sorted in alphabetical order:
 ```
    gcm -commandtype function |select  verb -unique |sort verb|ft
 
@@ -1201,8 +1184,7 @@ Because the return array may be redirected to a file and not all console output 
    Write-Vars > foo.out # 'B', 'D' to console; 'A', 'E', 'C' to foo.out
 
 ```
-One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case.
-More examples:
+One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case. More examples:
 ```
    function list-txt{ls *.txt}
    $a = list-txt  # No console output, output of ls returned.
@@ -1374,8 +1356,7 @@ Now follows a list of examples that may be useful in inspecting/traversing the R
    ls   -rec -depth 1 -ea 4 | measure -line   # gives   804 lines
 
 ```
-while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`.
-**End note**
+while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`. **End note**
 
 The following command lists names of subkeys and subsubkeys of the present key together with an array containing the names of their value entries:
 ```
@@ -1547,8 +1528,7 @@ The names of members (methods and properties) of an object can be obtained by pi
 
 A PSDrive is a collection of entities that are grouped such that they may be accessed as a filesystem drive. The grouping is performed by a "PSprovider". By default a PS session has access to about a dozen PSdrives among which `c:, env:, alias:, HKLM:`.  Here `c:` is the usual Windows c-drive; `env:` is the space of Windows environmental variables; `alias:` is the collection of cmdlet aliases; `HKLM` is a hive in the Registry.
 
-Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows:
-Switch to env:
+Standard one enters a PS session in the home folder (home directory) of the user. To switch a PS session to another PSdrive or folder and get the children of the new location, proceed as follows: Switch to env:
 
 ```
     Set-Location env:                 # Prompt character becomes `Env:\>`
@@ -2078,9 +2058,7 @@ The cmdlet `rename-item` can take piped input for the old name and recognizes 
 ```
 gives the required change of the file extension.
 
-To change multiple names at once, one may use the `-replace` operator. Its syntax is:
-    ` string -replace regexp, new_name`
-In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
+To change multiple names at once, one may use the `-replace` operator. Its syntax is: ` string -replace regexp, new_name` In `string` every substring that matches the regular expression `regexp` is replaced by `new_name`. For example,
 
 ```
      'report.txt' -replace '\.txt$', '.doc'  # -> 'report.doc'
@@ -2189,8 +2167,7 @@ The last statement (`$assoc`) gives:
 15Strings
 =========
 
-**Strings** are as in PHP.
-'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
+**Strings** are as in PHP. 'Singly' quoted strings: no expansion of variables or escape character (backtick). "Doubly" quoted: expansion of variables. Expressions under `$` are evaluated. For example,
 ```
       $five  = 5
       '3*$five'  -> 3*$five
@@ -2198,15 +2175,13 @@ The last statement (`$assoc`) gives:
       "$(3*5)" -> 15
 
 ```
-Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`.
-**Notes:**
+Backtick escapes under double quotes. For example, escaping the dollar symbol: `"`$(3*5)"` gives `$(3*5)`. Backticks are unchanged under single quotes: `'`$(3*5)'` gives `'`$(3*5)'`. **Notes:**
 
 1.  `"`n"` gives the newline character.
 2.  The string `"John Doe"` can be appended to a file simply by `"John Doe" >> out.txt`. The file `out.txt` will be in UTF-16.
 3.  The cmdlet `add-content` (alias `ac`) writes to file by default in ANSI (Windows-1252), and allows specification of other encodings.
 
-**Here-strings**
-`@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
+**Here-strings** `@' ... '@` (no expansion) and `@" ... "@` (with expansion). Note that the openings `@'` and `@"` must start in column 1 and be on a single line. The same holds for the endings `'@` and `"@`.
 
 Example, assume `$a -eq "Big Brother"`:
 ```
@@ -2354,8 +2329,7 @@ which returns the Windows environmental variable `path` with its entries stack
 17Comparison
 ============
 
-Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group.
-Examples:
+Comparison operators are among others: `-eq, -ne, -gt, -ge, -lt, -le, -like, -notlike, -match, -notmatch,` and `-cmatch`. Although the operator `-replace` does not perform a comparison, it is usually included in this group. Examples:
 ```
     'peanutbutter' -like 'nut'         # false
     'peanutbutter' -like '*nut*'       # true   (* is wildcard)
@@ -2409,8 +2383,7 @@ PowerShell has built-in classes, one is `[console]` with methods (among others
     [console]::readkey()          # Return name of key + modifier(not under ISE)
 
 ```
-Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx).
-Examples:
+Another built-in class is `[math]`. See [msdn](https://msdn.microsoft.com/en-us/library/system.math_methods(v=vs.110).aspx). Examples:
 ```
     [math]::pi                    # 3.14159265358979
     [math]::cos([math]::pi)       # -1
@@ -2464,8 +2437,7 @@ For instance, suppress error message about inaccessible subdirectories as follow
 
 ```
 
-As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1).
-Example of trapping:
+As in many languages errors may be trapped. Enter `Get-Help about_trap` to see how. The very same info as web page is here: [About trap](https://docs.microsoft.com/en-us/PowerShell/module/microsoft.PowerShell.core/about/about_trap?view=PowerShell-5.1). Example of trapping:
 
 ```
     Trap [System.Exception] {
@@ -2498,8 +2470,7 @@ The global object `$error` is a stack containing the consecutive non-trapped e
 22Functions
 ===========
 
-A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs.
-To get the unique verbs of all (including user) functions sorted in alphabetical order:
+A *PS function* is written in the PowerShell script language and is not compiled but interpreted. Often functions are written by end-users. In contrast, a cmdlet is written in a .net programming language such as `C#` ("C sharp") and is an intrinsic part of PS. A function name, just like a cmdlet name, is preferably of the form "verb-noun" where "verb" is any of the existing verbs. To get the unique verbs of all (including user) functions sorted in alphabetical order:
 ```
    gcm -commandtype function |select  verb -unique |sort verb|ft
 
@@ -2580,8 +2551,7 @@ Because the return array may be redirected to a file and not all console output 
    Write-Vars > foo.out # 'B', 'D' to console; 'A', 'E', 'C' to foo.out
 
 ```
-One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case.
-More examples:
+One could expect that the statement `Write-Vars` would write first the immediate values of `$b` and `$d` followed by the values of the return array, but this is not the case. More examples:
 ```
    function list-txt{ls *.txt}
    $a = list-txt  # No console output, output of ls returned.
@@ -2753,8 +2723,7 @@ Now follows a list of examples that may be useful in inspecting/traversing the R
    ls   -rec -depth 1 -ea 4 | measure -line   # gives   804 lines
 
 ```
-while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`.
-**End note**
+while both commands---issued from `c:\`---give the very same number of lines (542). It is difficult to see this dependence on context as anything but a bug. It is, therefore, advisable to never use `ls *` together with the flags `-rec -depth`. **End note**
 
 The following command lists names of subkeys and subsubkeys of the present key together with an array containing the names of their value entries:
 ```

--- a/pages/_notes/cheetsheets/bash.md
+++ b/pages/_notes/cheetsheets/bash.md
@@ -28,8 +28,7 @@ lastmod: 2022-08-07T14:49:51.999Z
 
 test
 
-Getting started
-{: .cols-3 }
+Getting started {: .cols-3 }
 
 ---------------
 

--- a/pages/_notes/cheetsheets/command-line.md
+++ b/pages/_notes/cheetsheets/command-line.md
@@ -39,9 +39,7 @@ $gh_repo = "bamr87/it-journey"
 gh repo fork $gh_repo --clone=true
 ```
 
-wmic 
-/output:C:\Temp\list.txt product get name, version
-exit
+wmic /output:C:\Temp\list.txt product get name, version exit
 
 ```powershell
 

--- a/pages/_notes/cheetsheets/markdown.md
+++ b/pages/_notes/cheetsheets/markdown.md
@@ -63,8 +63,7 @@ var rawr = ["r", "a", "w", "r"];
 creates...
 
 {% highlight javascript %}
-/* Some pointless Javascript */
-var rawr = ["r", "a", "w", "r"];
+/* Some pointless Javascript */ var rawr = ["r", "a", "w", "r"];
 {% endhighlight %}
  
 Use two trailing spaces  

--- a/pages/_notes/index.md
+++ b/pages/_notes/index.md
@@ -164,15 +164,11 @@ Golden Ratio
 \phi = \frac{1+\sqrt{5}}{2}
 ```
 
-\begin{equation}
-\phi = \frac{1+\sqrt{5}}{2}
-\end{equation}
+\begin{equation} \phi = \frac{1+\sqrt{5}}{2} \end{equation}
 
 $$ \phi = \frac{1+\sqrt{5}}{2} $$ is the golden ratio
 
-\begin{align}
-\phi = \frac{1+\sqrt{5}}{2}
-\end{align}
+\begin{align} \phi = \frac{1+\sqrt{5}}{2} \end{align}
 
 ## Auto Name Code Snippet
 
@@ -224,9 +220,7 @@ p, img
 
 ### Examples
 
-![this is a caption](../assets/images/nubi-son.png)
-![Nubi in a sink](../assets/images/nubi-sink.png)
-![Nubi yawning](../assets/images/nubi-yawn.png){: .img-thumbnail }
+![this is a caption](../assets/images/nubi-son.png) ![Nubi in a sink](../assets/images/nubi-sink.png) ![Nubi yawning](../assets/images/nubi-yawn.png){: .img-thumbnail }
 
 
 > this is a block quote

--- a/pages/_notes/misc/AWS Practice Question Set.md
+++ b/pages/_notes/misc/AWS Practice Question Set.md
@@ -655,8 +655,7 @@ For more information about QuickSight, see What Is Amazon QuickSight?
  
 ## 1.3 Prepare the application deployment package to be deployed to AWS.
 
-1/20
-0.0% complete
+1/20 0.0% complete
  
 A developer is preparing a deployment package for a Java implementation of an AWS Lambda function.
 
@@ -664,8 +663,7 @@ What should the developer include in the deployment package? (Select TWO.)
 
 Report Content Errors
 
-A
-Compiled application code
+A Compiled application code
 
 Correct. To create a Lambda function, you first create a Lambda function deployment package. This deployment package is a .zip or .jar file consisting of your code and any dependencies.
 
@@ -674,32 +672,28 @@ For more information about Lambda deployment packages, see Lambda deployment pac
 For more information about deploying a Lambda application, see Creating an application with continuous delivery in the Lambda console.
 
 
-B
-Java runtime environment
+B Java runtime environment
 
 Incorrect. Lambda provides Java runtime, so there is no need to include it in the deployment package.
 
 For more information about building Lambda functions with Java, see Building Lambda functions with Java.
 
 
-C
-References to the event sources
+C References to the event sources
 
 Incorrect. The event sources are external to Lambda and are used to invoke a Lambda function. As such, event sources are not part of a Lambda deployment package.
 
 For more information about event source mapping in Lambda, see AWS Lambda event source mappings.
 
 
-D
-Lambda execution role
+D Lambda execution role
 
 Incorrect. A Lambda execution role is an IAM role that grants the function permission to access AWS services and resources. This role is provided when a Lambda function is created. It is not included in the deployment package.
 
 For more information about Lambda execution roles, see AWS Lambda execution role.
 
 
-E
-Application dependencies
+E Application dependencies
 
 Correct. To create a Lambda function, you first create a Lambda function deployment package. This package is a .zip or .jar file consisting of your code and any dependencies.
 
@@ -717,12 +711,9 @@ AE
 
 
  
-1.3 Prepare the application deployment package to be deployed to AWS.
- This Question: 00:33
- Total: 01:31
+1.3 Prepare the application deployment package to be deployed to AWS. This Question: 00:33 Total: 01:31
 
-2/20
-5.0% complete
+2/20 5.0% complete
  
 A developer uses AWS CodeDeploy to deploy a Python application to a fleet of Amazon EC2 instances that run behind an Application Load Balancer. The instances run in an Amazon EC2 Auto Scaling group across multiple Availability Zones.
 
@@ -730,8 +721,7 @@ What should the developer include in the CodeDeploy deployment package?
 
 Report Content Errors
 
-A
-A launch template for the Amazon EC2 Auto Scaling group
+A A launch template for the Amazon EC2 Auto Scaling group
 
 Incorrect. A launch template for the Auto Scaling group is configured in Amazon EC2 AutoScaling. It is not configured in a CodeDeploy package.
 
@@ -740,16 +730,14 @@ For more information about Amazon EC2 Auto Scaling and how to configure it, see 
 For more information about Amazon EC2 Auto Scaling with a tutorial, see Getting started with Amazon EC2 Auto Scaling.
 
 
-B
-A CodeDeploy AppSpec file
+B A CodeDeploy AppSpec file
 
 Correct. The CodeDeploy AppSpec (application specific) file is unique to CodeDeploy. The AppSpec file is used to manage each deployment as a series of lifecycle event hooks, which are defined in the file.
 
 For more information about AppSpec files, see CodeDeploy application specification (AppSpec) files.
 
 
-C
-An EC2 role that grants the application access to AWS services
+C An EC2 role that grants the application access to AWS services
 
 Incorrect. An IAM policy by itself does not grant access to AWS services. The policy must be assigned to an IAM role. The role must be assigned to the instances to provide access.
 
@@ -758,8 +746,7 @@ For more information about IAM roles, see IAM roles.
 For more information about IAM roles on EC2 instances, see IAM roles for Amazon EC2.
 
 
-D
-An IAM policy that grants the application access to AWS services
+D An IAM policy that grants the application access to AWS services
 
 Incorrect. An IAM policy that grants access to AWS services is attached to IAM users, groups, or roles. You cannot attach an IAM policy to an application.
 
@@ -775,12 +762,9 @@ B
 
 
  
-1.4 Deploy serverless applications.
- This Question: 01:49
- Total: 03:20
+1.4 Deploy serverless applications. This Question: 01:49 Total: 03:20
 
-3/20
-10.0% complete
+3/20 10.0% complete
  
 A company is working on a project to enhance its serverless application development process. The company hosts applications on AWS Lambda. The development team regularly updates the Lambda code and wants to use stable code in production.
 
@@ -788,16 +772,14 @@ Which combination of steps should the development team take to configure Lambda 
 
 Report Content Errors
 
-A
-Create a new Lambda version every time a new code release needs testing.
+A Create a new Lambda version every time a new code release needs testing.
 
 Correct. Lambda function versions are designed to manage deployment of functions. They can be used for code changes, without affecting the stable production version of the code.
 
 For more information about Lambda function versions, see Lambda function versions.
 
 
-B
-Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready unqualified Amazon Resource Name (ARN) version. Point the Development alias to the $LATEST version.
+B Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready unqualified Amazon Resource Name (ARN) version. Point the Development alias to the $LATEST version.
 
 Correct. By creating separate aliases for Production and Development, systems can initiate the correct alias as needed. A Lambda function alias can be used to point to a specific Lambda function version. Using the functionality to update an alias and its linked version, the development team can update the required version as needed. The $LATEST version is the newest published version.
 
@@ -806,8 +788,7 @@ For more information about Lambda function aliases, see Lambda function aliases.
 For more information about Lambda function versions, see Lambda function versions.
 
 
-C
-Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to the production-ready qualified Amazon Resource Name (ARN) version. Point the Development alias to the variable LAMBDA_TASK_ROOT.
+C Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to the production-ready qualified Amazon Resource Name (ARN) version. Point the Development alias to the variable LAMBDA_TASK_ROOT.
 
 Incorrect. A Lambda function alias can only point to an unqualified function ARN. LAMBDA_TASK_ROOT is a variable used by Lambda to record the path to the code. However, it cannot be used in the way the response describes.
 
@@ -816,16 +797,14 @@ For more information about Lambda function versions, see Lambda function version
 For more information about Lambda variables, see Configuring environment variables.
 
 
-D
-Create a new Lambda layer every time a new code release needs testing.
+D Create a new Lambda layer every time a new code release needs testing.
 
 Incorrect. Using a Lambda layer, you can access additional code and content. It is not suitable for code updates.
 
 For more information about Lambda layers, see Creating and sharing Lambda layers.
 
 
-E
-Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready Lambda layer Amazon Resource Name (ARN). Point the Development alias to the $LATEST layer ARN.
+E Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready Lambda layer Amazon Resource Name (ARN). Point the Development alias to the $LATEST layer ARN.
 
 Incorrect. Using a Lambda layer, you can access additional code and content. It is not suitable for code updates. Additionally, a Lambda function alias points to a Lambda function version.
 
@@ -843,12 +822,9 @@ AB
 
 
  
-1.4 Deploy serverless applications.
- This Question: 01:08
- Total: 04:29
+1.4 Deploy serverless applications. This Question: 01:08 Total: 04:29
 
-4/20
-15.0% complete
+4/20 15.0% complete
  
 Each time a developer publishes a new version of an AWS Lambda function, all the dependent event source mappings need to be updated with the reference to the new version’s Amazon Resource Name (ARN). These updates are time consuming and error-prone.
 
@@ -856,8 +832,7 @@ Which combination of actions should the developer take to avoid performing these
 
 Report Content Errors
 
-A
-Update event source mappings with the ARN of the Lambda layer.
+A Update event source mappings with the ARN of the Lambda layer.
 
 Incorrect. A Lambda event source mapping can either point to the version ARN, or an alias ARN, but not to the layer ARN.
 
@@ -868,32 +843,28 @@ For more information about creating and using Lambda function aliases, see Lambd
 For more information about Lambda layers, see Creating and sharing Lambda layers.
 
 
-B
-Point a Lambda alias to a new version of the Lambda function.
+B Point a Lambda alias to a new version of the Lambda function.
 
 Correct. A Lambda alias is a pointer to a specific Lambda function version.
 
 For more information about creating and using Lambda function aliases, see Lambda function aliases.
 
 
-C
-Create a Lambda alias for each published version of the Lambda function.
+C Create a Lambda alias for each published version of the Lambda function.
 
 Incorrect. This solution does not address your problem. Every alias has its own unique ARN. Therefore, you would still need to update the event source mapping with the new ARN when a new version is published.
 
 For more information about creating and using Lambda function aliases, see Lambda function aliases.
 
 
-D
-Point a Lambda alias to a new Lambda function alias.
+D Point a Lambda alias to a new Lambda function alias.
 
 Incorrect. A Lambda alias cannot point to another Lambda alias, only to a Lambda function version.
 
 For more information about Lambda function aliases, including their creation and management, see Using aliases.
 
 
-E
-Update the event source mappings with the Lambda alias ARN.
+E Update the event source mappings with the Lambda alias ARN.
 
 Correct. Instead of using ARNs for the Lambda function in event source mappings, you can use an alias ARN. You do not need to update your event source mappings when you promote a new version or roll back to a previous version.
 
@@ -909,12 +880,9 @@ BE
 
 
  
-2.1 Make authenticated calls to AWS services.
- This Question: 00:23
- Total: 04:53
+2.1 Make authenticated calls to AWS services. This Question: 00:23 Total: 04:53
 
-5/20
-20.0% complete
+5/20 20.0% complete
  
 An application that runs on Amazon EC2 instances needs credentials to make an API call to Amazon DynamoDB.
 
@@ -922,32 +890,28 @@ What is the MOST secure method to provide credentials to perform the call?
 
 Report Content Errors
 
-A
-Create a user and a password with the needed permissions. Store the credentials in a configuration file on the EC2 instances.
+A Create a user and a password with the needed permissions. Store the credentials in a configuration file on the EC2 instances.
 
 Incorrect. You could store AWS credentials directly within the EC2 instances and allow applications that run on those instances to use those credentials. However, you would have to manage the credentials. You would have to securely pass the credentials to each instance and update each instance when it is time to rotate the credentials. This approach is not the most secure solution.
 
 For more information about using an IAM role to grant permissions to applications running on EC2 instances, see Use roles for applications that run on Amazon EC2 instances. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-roles-with-ec2
 
 
-B
-Assign an IAM role with the correct permissions to the DynamoDB table.
+B Assign an IAM role with the correct permissions to the DynamoDB table.
 
 Incorrect. While roles are the most secure way to provide these credentials, it is the EC2 instance that is making the API call. The instances, not the DynamoDB table, need to be assigned the proper credentials.
 
 For more information about using an IAM role to grant permissions to applications running on EC2 instances, see Use roles for applications that run on Amazon EC2 instances. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-roles-with-ec2
 
 
-C
-Assign an IAM role with the correct permissions to the EC2 instances.
+C Assign an IAM role with the correct permissions to the EC2 instances.
 
 Correct. The most secure method is to create an IAM role with the appropriate policy. Attach that IAM role to the EC2 instance that is making the API call. Long-term credentials are not stored, which reduces risk of compromising the credentials.
 
 For more information about using an IAM role to grant permissions to applications running on EC2 instances, see Use roles for applications that run on Amazon EC2 instances.
 
 
-D
-Add the name of an IAM policy with the correct permissions to a configuration file on the instances.
+D Add the name of an IAM policy with the correct permissions to a configuration file on the instances.
 
 Incorrect. IAM policies are associated with IAM identities (users, groups, or roles) or AWS resources. A configuration file of instances is not an IAM identity or an AWS resource. Therefore, an IAM policy cannot be associated with it.
 
@@ -963,12 +927,9 @@ C
 
 
  
-2.2 Implement encryption using AWS services.
- This Question: 01:17
- Total: 06:10
+2.2 Implement encryption using AWS services. This Question: 01:17 Total: 06:10
 
-6/20
-25.0% complete
+6/20 25.0% complete
  
 A company wants to store sensitive user data in Amazon S3 and encrypt this data at rest. The company must manage the encryption keys and use Amazon S3 to perform the encryption.
 
@@ -976,30 +937,26 @@ How can a developer meet these requirements?
 
 Report Content Errors
 
-A
-Enable default encryption for the S3 bucket by using the option for server-side encryption with customer-provided encryption keys (SSE-C).
+A Enable default encryption for the S3 bucket by using the option for server-side encryption with customer-provided encryption keys (SSE-C).
 
 Incorrect. The default encryption behavior for an S3 bucket can be configured to either SSE-S3 or customer master keys (CMKs) stored in AWS Key Management Service (AWS KMS) (SSE-KMS). Although you can upload files with SSE-C, you cannot set it as a default S3 bucket encryption.
 
 For more information about S3 encryption, see Setting default server-side encryption behavior for Amazon S3 buckets.
 
 
-B
-Enable client-side encryption with an encryption key. Upload the encrypted object to the S3 bucket.
+B Enable client-side encryption with an encryption key. Upload the encrypted object to the S3 bucket.
 
 Incorrect. Client-side encryption involves encrypting data before sending it to Amazon S3. This solution does not meet the requirement for Amazon to provide the encryption.
 
 For more information about client-side encryption for S3 buckets, see Protecting data using client-side encryption.
 
 
-C
-Enable server-side encryption with Amazon S3 managed encryption keys (SSE-S3). Upload an object to the S3 bucket.
+C Enable server-side encryption with Amazon S3 managed encryption keys (SSE-S3). Upload an object to the S3 bucket.
 
 Incorrect. SSE-S3 uses an encryption key provided by Amazon S3 to encrypt data. This solution does not meet the requirement for the company to manage the encryption keys.
 
 
-D
-Enable server-side encryption with customer-provided encryption keys (SSE-C). Upload an object to the S3 bucket.
+D Enable server-side encryption with customer-provided encryption keys (SSE-C). Upload an object to the S3 bucket.
 
 Correct. When you upload an object, Amazon S3 uses the encryption key you provide to apply AES-256 encryption to your data and removes the encryption key from memory.
 
@@ -1015,12 +972,9 @@ D
 
 
  
-2.2 Implement encryption using AWS services.
- This Question: 01:29
- Total: 07:40
+2.2 Implement encryption using AWS services. This Question: 01:29 Total: 07:40
 
-7/20
-30.0% complete
+7/20 30.0% complete
  
 A company is developing a Python application that submits data to an Amazon DynamoDB table. The company requires client-side encryption of specific data items and end-to-end protection for the encrypted data in transit and at rest.
 
@@ -1028,8 +982,7 @@ Which combination of steps will meet the requirement for the encryption of speci
 
 Report Content Errors
 
-A
-Generate symmetric encryption keys with AWS Key Management Service (AWS KMS).
+A Generate symmetric encryption keys with AWS Key Management Service (AWS KMS).
 
 Correct. When the DynamoDB Encryption Client is configured to use AWS KMS, it uses a customer master key (CMK) that is always encrypted when used outside of AWS KMS. This cryptographic materials provider returns a unique encryption key and signing key for every table item. This method of encryption uses a symmetric CMK.
 
@@ -1038,8 +991,7 @@ For more information about the Direct KMS Materials Provider used by the DynamoD
 For more information about CMKs, see AWS Key Management Service concepts.
 
 
-B
-Generate asymmetric encryption keys with AWS Key Management Service (AWS KMS).
+B Generate asymmetric encryption keys with AWS Key Management Service (AWS KMS).
 
 Incorrect. When the DynamoDB Encryption Client is configured to use AWS KMS, it uses a customer master key (CMK) that is always encrypted when used outside of AWS KMS. This cryptographic materials provider returns a unique encryption key and signing key for every table item. This method of encryption would require a symmetric CMK, not an asymmetric key.
 
@@ -1048,8 +1000,7 @@ For more information about the Direct KMS Materials Provider, see Direct KMS Mat
 For more information about CMKs, see AWS Key Management Service concepts.
 
 
-C
-Use generated keys with the DynamoDB Encryption Client.
+C Use generated keys with the DynamoDB Encryption Client.
 
 Correct. The DynamoDB Encryption Client provides end-to-end protection for your data in transit and at rest. You can encrypt selected items or attribute values in a table.
 
@@ -1060,8 +1011,7 @@ For more information about the DynamoDB Encryption Client, see What is the Amazo
 For more information about DynamoDB Encryption Client, see How the DynamoDB Encryption Client works.
 
 
-D
-Use generated keys to configure DynamoDB table encryption with AWS managed customer master keys (CMKs).
+D Use generated keys to configure DynamoDB table encryption with AWS managed customer master keys (CMKs).
 
 Incorrect. This method is used for server-side encryption at rest. This solution does not meet the requirement for client-side encryption.
 
@@ -1070,8 +1020,7 @@ For more information about DynamoDB client-side and server-side encryption, see 
 For more information about DynamoDB encryption at rest, see DynamoDB Encryption at Rest.
 
 
-E
-Use generated keys to configure DynamoDB table encryption with AWS owned customer master keys (CMKs).
+E Use generated keys to configure DynamoDB table encryption with AWS owned customer master keys (CMKs).
 
 Incorrect. This method is used for server-side encryption at rest. This solution does not meet the requirement for client-side encryption.
 
@@ -1089,12 +1038,9 @@ AC
 
 
  
-2.3 Implement application authentication and authorization.
- This Question: 02:14
- Total: 09:54
+2.3 Implement application authentication and authorization. This Question: 02:14 Total: 09:54
 
-8/20
-35.0% complete
+8/20 35.0% complete
  
 A company is developing a REST API with Amazon API Gateway. Access to the API should be limited to users in the existing Amazon Cognito user pool.
 
@@ -1102,16 +1048,14 @@ Which combination of steps should a developer perform to secure the API? (Select
 
 Report Content Errors
 
-A
-Create an AWS Lambda authorizer for the API.
+A Create an AWS Lambda authorizer for the API.
 
 Incorrect. A Lambda authorizer is an API Gateway feature that uses a Lambda function to implement a custom authorization scheme to control access to your API. This solution works if the users are authenticated with OAuth or SAML. However, a Lambda authorizer does not fit this scenario.
 
 For more information about using the Lambda authorizer, see Use API Gateway Lambda authorizers.
 
 
-B
-Create an Amazon Cognito authorizer for the API.
+B Create an Amazon Cognito authorizer for the API.
 
 Correct. An Amazon Cognito authorizer should be used for integration with Amazon Cognito user pools.
 
@@ -1120,16 +1064,14 @@ For more information about how to control access to a REST API by using Amazon C
 For more information about how to integrate a REST API with an Amazon Cognito user pool, see Integrate a REST API with an Amazon Cognito user pool.
 
 
-C
-Configure the authorizer for the API resource.
+C Configure the authorizer for the API resource.
 
 Incorrect. The authorizer cannot be configured for the API resource.
 
 For more information about how to control access to a REST API by using Amazon Cognito user pools, see Control access to a REST API using Amazon Cognito user pools as authorizer.
 
 
-D
-Configure the API methods to use the authorizer.
+D Configure the API methods to use the authorizer.
 
 Correct. In addition to creating an authorizer, you are required to configure an API method to use that authorizer for the API.
 
@@ -1138,8 +1080,7 @@ For more information about how to configure the API methods to use the authorize
 For more information about how to integrate a REST API with an Amazon Cognito user pool, see Integrate a REST API with an Amazon Cognito user pool.
 
 
-E
-Configure the authorizer for the API stage.
+E Configure the authorizer for the API stage.
 
 Incorrect. The authorizer cannot be configured in the API stage.
 
@@ -1154,12 +1095,9 @@ BD
 
 
  
-2.3 Implement application authentication and authorization.
- This Question: 01:12
- Total: 11:07
+2.3 Implement application authentication and authorization. This Question: 01:12 Total: 11:07
 
-9/20
-40.0% complete
+9/20 40.0% complete
  
 A developer is implementing a mobile app to provide personalized services to app users. The application code makes calls to Amazon S3 and Amazon Simple Queue Service (Amazon SQS).
 
@@ -1167,40 +1105,35 @@ Which options can the developer use to authenticate the app users? (Select TWO.)
 
 Report Content Errors
 
-A
-Authenticate to the Amazon Cognito identity pool directly.
+A Authenticate to the Amazon Cognito identity pool directly.
 
 Incorrect. The Amazon Cognito identity pool does not provide the application with user authentication service. Your application can use identity pools to exchange user pool tokens for AWS credentials.
 
 For more information about Amazon Cognito, see What Is Amazon Cognito?
 
 
-B
-Authenticate to AWS Identity and Access Management (IAM) directly.
+B Authenticate to AWS Identity and Access Management (IAM) directly.
 
 Incorrect. IAM does not provide the application with direct user authentication service. You use IAM users to control access to AWS.
 
 For more information about IAM users, see IAM users.
 
 
-C
-Authenticate to the Amazon Cognito user pool directly.
+C Authenticate to the Amazon Cognito user pool directly.
 
 Correct. The Amazon Cognito user pool provides direct user authentication.
 
 For more information about Amazon Cognito user pools, see Adding User Pool Sign-in Through a Third Party.
 
 
-D
-Federate authentication by using Login with Amazon with the users managed with AWS Security Token Service (AWS STS).
+D Federate authentication by using Login with Amazon with the users managed with AWS Security Token Service (AWS STS).
 
 Incorrect. AWS STS does not provide the application with user authentication service. It is used to request temporary credentials for IAM users. All the users would have to have IAM users, and that would be cumbersome to manage.
 
 For more information about AWS STS, see Welcome to the AWS Security Token Service API Reference.
 
 
-E
-Federate authentication by using Login with Amazon with the users managed with the Amazon Cognito user pool.
+E Federate authentication by using Login with Amazon with the users managed with the Amazon Cognito user pool.
 
 Correct. The Amazon Cognito user pool provides a federated authentication option with third-party identity provider (IdP), including amazon.com.
 
@@ -1215,12 +1148,9 @@ CE
 
 
  
-3.1 Write code for serverless applications.
- This Question: 01:15
- Total: 12:22
+3.1 Write code for serverless applications. This Question: 01:15 Total: 12:22
 
-10/20
-45.0% complete
+10/20 45.0% complete
  
 A company is implementing several order processing workflows. Each workflow is implemented by using AWS Lambda functions for each task.
 
@@ -1228,8 +1158,7 @@ Which combination of steps should a developer follow to implement these workflow
 
 Report Content Errors
 
-A
-Define a AWS Step Functions task for each Lambda function.
+A Define a AWS Step Functions task for each Lambda function.
 
 Correct. Step Functions is based on state machines and tasks. A state machine is a workflow. Tasks perform work by coordinating with other AWS services, such as Lambda.
 
@@ -1238,16 +1167,14 @@ For more information about Step Functions tasks, see Task.
 For more information about Step Functions, see Getting Started with AWS Step Functions.
 
 
-B
-Define a AWS Step Functions task for each workflow.
+B Define a AWS Step Functions task for each workflow.
 
 Incorrect. A Step Functions workflow is implemented with one or more tasks.
 
 For more information about Step Functions tasks, see Task.
 
 
-C
-Write code that polls the AWS Step Functions invocation to coordinate each workflow.
+C Write code that polls the AWS Step Functions invocation to coordinate each workflow.
 
 Incorrect. You do not need to poll the Step Functions invocation to coordinate the workflow. State machines are precisely designed to coordinate the workflow.
 
@@ -1256,8 +1183,7 @@ For more information about Step Functions tasks, see Task.
 For more information about Step Functions, see Getting Started with AWS Step Functions.
 
 
-D
-Define an AWS Step Functions state machine for each workflow.
+D Define an AWS Step Functions state machine for each workflow.
 
 Correct. A state machine is a workflow. It can be used to express a workflow as a number of states, their relationships, and their input and output. You can coordinate individual tasks with Step Functions by expressing your workflow as a finite state machine, written in the Amazon States Language.
 
@@ -1266,8 +1192,7 @@ For more information about the Standard and Express workflows of Step Functions,
 For more information about states of Step Functions, see States.
 
 
-E
-Define an AWS Step Functions state machine for each Lambda function.
+E Define an AWS Step Functions state machine for each Lambda function.
 
 Incorrect. A Step Functions state machine represents a workflow and not a Lambda function. A Lambda function would be represented as a task.
 
@@ -1282,12 +1207,9 @@ AD
 
 
  
-3.2 Translate functional requirements into application design.
- This Question: 01:08
- Total: 13:26
+3.2 Translate functional requirements into application design. This Question: 01:08 Total: 13:26
 
-11/20
-50.0% complete
+11/20 50.0% complete
  
 A company is migrating a web service to the AWS Cloud. The web service accepts requests by using HTTP (port 80). The company wants to use an AWS Lambda function to process HTTP requests.
 
@@ -1295,32 +1217,28 @@ Which application design will satisfy these requirements?
 
 Report Content Errors
 
-A
-Create an Amazon API Gateway API. Configure proxy integration with the Lambda function.
+A Create an Amazon API Gateway API. Configure proxy integration with the Lambda function.
 
 Incorrect. API Gateway does not support unencrypted (HTTP) endpoints. HTTP is required in this scenario.
 
 For more information about API Gateway endpoint protocols, see Amazon API Gateway FAQs (Q: Can I create HTTPS endpoints?)
 
 
-B
-Create an Amazon API Gateway API. Configure non-proxy integration with the Lambda function.
+B Create an Amazon API Gateway API. Configure non-proxy integration with the Lambda function.
 
 Incorrect. API Gateway does not support unencrypted (HTTP) endpoints. HTTP is required in this scenario.
 
 For more information about API Gateway endpoint protocols, see Amazon API Gateway FAQs (Q: Can I create HTTPS endpoints?)
 
 
-C
-Configure the Lambda function to listen to inbound network connections on port 80.
+C Configure the Lambda function to listen to inbound network connections on port 80.
 
 Incorrect. Lambda blocks inbound network connections. Although you cannot directly invoke a Lambda function, other supported services can invoke a function.
 
 For more information about using Lambda with other services, see Using AWS Lambda with other services.
 
 
-D
-Configure the Lambda function as a target in the Application Load Balancer target group.
+D Configure the Lambda function as a target in the Application Load Balancer target group.
 
 Correct. Elastic Load Balancing supports Lambda functions as a target for an Application Load Balancer. You can use load balancer rules to route HTTP requests to a function, based on the path or the header values. Then, process the request and return an HTTP response from your Lambda function.
 
@@ -1336,12 +1254,9 @@ D
 
 
  
-3.2 Translate functional requirements into application design.
- This Question: 01:00
- Total: 14:27
+3.2 Translate functional requirements into application design. This Question: 01:00 Total: 14:27
 
-12/20
-55.0% complete
+12/20 55.0% complete
  
 A company is developing an image processing application. When an image is uploaded to an Amazon S3 bucket, a number of independent and separate services must be invoked to process the image. The services do not have to be available immediately, but they must process every image.
 
@@ -1349,32 +1264,28 @@ Which application design satisfies these requirements?
 
 Report Content Errors
 
-A
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Each service pulls the message from the same queue.
+A Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Each service pulls the message from the same queue.
 
 Incorrect. After a consumer retrieves and processes a message from a queue, it deletes the message in the queue. The result is that only one service receives the message.
 
 For more information about Amazon SQS architecture, see Basic Amazon SQS architecture.
 
 
-B
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Each service subscribes to the same topic.
+B Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Each service subscribes to the same topic.
 
 Incorrect. An Amazon SQS delivery policy defines how Amazon SNS retries the delivery of messages when a delivery error occurs. Amazon SNS stops retrying the delivery and discards the message when a delivery policy is exhausted. If one of the services is temporarily unavailable, it would not receive the message.
 
 For more information about Amazon SNS message delivery retries, see Amazon SNS message delivery retries.
 
 
-C
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Subscribe a separate Amazon Simple Notification Service (Amazon SNS) topic for each service to an Amazon SQS queue.
+C Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Subscribe a separate Amazon Simple Notification Service (Amazon SNS) topic for each service to an Amazon SQS queue.
 
 Incorrect. An Amazon SQS queue is not a supported event source for Amazon SNS.
 
 For more information about Amazon SNS event sources, see Amazon SNS event sources.
 
 
-D
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe a separate Simple Queue Service (Amazon SQS) queue for each service to the Amazon SNS topic.
+D Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe a separate Simple Queue Service (Amazon SQS) queue for each service to the Amazon SNS topic.
 
 Correct. Each service can subscribe to an individual Amazon SQS queue, which receives an event notification from the Amazon SNS topic. This is a fanout architectural implementation.
 
@@ -1389,12 +1300,9 @@ D
 
 
  
-3.3 Implement application design into application code.
- This Question: 00:53
- Total: 15:20
+3.3 Implement application design into application code. This Question: 00:53 Total: 15:20
 
-13/20
-60.0% complete
+13/20 60.0% complete
  
 A developer wants to implement Amazon EC2 Auto Scaling for a Multi-AZ web application. However, the developer is concerned that user sessions will be lost during scale-in events.
 
@@ -1402,24 +1310,21 @@ How can the developer store the session state and share it across the EC2 instan
 
 Report Content Errors
 
-A
-Write the sessions to an Amazon Kinesis data stream. Configure the application to poll the stream.
+A Write the sessions to an Amazon Kinesis data stream. Configure the application to poll the stream.
 
 Incorrect. A Kinesis data stream is used for data ingestion and for processing of data records. However, it does not have the features needed for this use case. ElastiCache is better suited for this requirement.
 
 For more information about Kinesis, see Getting started with Amazon Kinesis Data Streams.
 
 
-B
-Publish the sessions to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe each instance in the group to the topic.
+B Publish the sessions to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe each instance in the group to the topic.
 
 Incorrect. Amazon SNS is used for publish-subscribe messaging. Messages are delivered as soon as they are sent. Amazon SNS is not designed to store persistent session data.
 
 For more information about SNS, see Amazon SNS FAQs.
 
 
-C
-Store the sessions in an Amazon ElastiCache for Memcached cluster. Configure the application to use the Memcached API.
+C Store the sessions in an Amazon ElastiCache for Memcached cluster. Configure the application to use the Memcached API.
 
 Correct. ElastiCache for Memcached is a distributed in-memory data store or cache environment in the cloud. It will meet the developer's requirement of persistent storage and is fast to access.
 
@@ -1428,8 +1333,7 @@ For more information about ElastiCache, see What is Amazon ElastiCache for Memca
 For more information about Memcached, see Amazon ElastiCache for Memcached.
 
 
-D
-Write the sessions to an Amazon Elastic Block Store (Amazon EBS) volume. Mount the volume to each instance in the group.
+D Write the sessions to an Amazon Elastic Block Store (Amazon EBS) volume. Mount the volume to each instance in the group.
 
 Incorrect. This solution would not synchronize the session data across all instances. Amazon EBS volumes are instance specific.
 
@@ -1442,12 +1346,9 @@ C
 
 
  
-3.3 Implement application design into application code.
- This Question: 00:44
- Total: 16:04
+3.3 Implement application design into application code. This Question: 00:44 Total: 16:04
 
-14/20
-65.0% complete
+14/20 65.0% complete
  
 A developer is writing a component that will read customer orders from an Amazon Simple Queue Service (Amazon SQS) queue and process them. The developer wants to reduce empty responses to the ReceiveMessage call and obtain a customer order message as soon as it is available.
 
@@ -1455,16 +1356,14 @@ What should the developer do when writing code to retrieve messages from the que
 
 Report Content Errors
 
-A
-Use SQS short polling.
+A Use SQS short polling.
 
 Incorrect. SQS short polling queries only a random subset of the servers for messages. To retrieve all messages, you might need multiple short queries. If the selected servers do not contain any messages, then empty responses would be sent. Additionally, short polling sends a response right away. These factors could result in empty responses.
 
 For more information about SQS queries, see Amazon SQS short and long polling.
 
 
-B
-Use SQS long polling.
+B Use SQS long polling.
 
 Correct. SQS long polling queries all servers for messages and sends a response after it collects at least one available message. Additionally, long polling would send an empty response only if the queue is empty and the polling wait time expires.
 
@@ -1473,16 +1372,14 @@ For more information about SQS queries, see Amazon SQS short and long polling.
 For more information about the ReceiveMessage API call, see ReceiveMessage.
 
 
-C
-Extend the visibility timeout.
+C Extend the visibility timeout.
 
 Incorrect. When a consumer receives and processes a message from an SQS queue, the message remains in the queue until the consumer deletes the message from the queue. To avoid other consumers from processing the same message, you can specify a visibility timeout value. A visibility timeout value is a period of time during which SQS prevents other consumers from receiving and processing the message.
 
 For more information about visibility timeouts for Amazon SQS, see Amazon SQS visibility timeout.
 
 
-D
-Increase the maximum number of messages to return.
+D Increase the maximum number of messages to return.
 
 Incorrect. Although a single ReceiveMessage response can include multiple messages, an increase in the MaxNumberOfMessages parameter will not ensure that all servers are queried for messages.
 
@@ -1497,12 +1394,9 @@ B
 
 
  
-3.4 Write code that interacts with AWS services by using APIs, SDKs, and AWS CLI.
- This Question: 01:17
- Total: 17:22
+3.4 Write code that interacts with AWS services by using APIs, SDKs, and AWS CLI. This Question: 01:17 Total: 17:22
 
-15/20
-70.0% complete
+15/20 70.0% complete
  
 A developer is integrating a legacy web application that runs on a fleet of Amazon EC2 instances with an Amazon DynamoDB table. There is no AWS SDK for the programming language that was used to implement the web application.
 
@@ -1510,38 +1404,33 @@ Which combination of steps should the developer perform to make an API call to A
 
 Report Content Errors
 
-A
-Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include an XML document that contains the request attributes.
+A Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include an XML document that contains the request attributes.
 
 Incorrect. The XML data format is not used for HTTPS-based low-level API calls.
 
 For more information about API calls to DynamoDB, see DynamoDB Low-Level API.
 
 
-B
-Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include a JSON document that contains the request attributes.
+B Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include a JSON document that contains the request attributes.
 
 Correct. The HTTPS-based low-level AWS API for DynamoDB uses JSON as a wire protocol format.
 
 For more information about API calls to DynamoDB, see DynamoDB Low-Level API.
 
 
-C
-Sign the requests by using AWS access keys and Signature Version 4.
+C Sign the requests by using AWS access keys and Signature Version 4.
 
 Correct. When you send HTTP requests to AWS, you sign the requests so that AWS can identify who sent them. Requests are signed with your AWS access key, which consists of an access key ID and secret access key. AWS supports two signature versions: Signature Version 4 and Signature Version 2. AWS recommends the use of Signature Version 4.
 
 For more information about signing AWS API requests, see Signing AWS API requests.
 
 
-D
-Use an EC2 SSH key to calculate Signature Version 4 of the request.
+D Use an EC2 SSH key to calculate Signature Version 4 of the request.
 
 Incorrect. An SSH key cannot be used to calculate Signature Version 4 of the low-level API request.
 
 
-E
-Provide the signature value through the HTTP X-API-Key header.
+E Provide the signature value through the HTTP X-API-Key header.
 
 Incorrect. The proper HTTP header for the signature value in low-level API calls is Authorization.
 
@@ -1557,12 +1446,9 @@ BC
 
 
  
-4.1 Optimize applications to best use AWS services and features
- This Question: 03:14
- Total: 20:36
+4.1 Optimize applications to best use AWS services and features This Question: 03:14 Total: 20:36
 
-16/20
-75.0% complete
+16/20 75.0% complete
  
 A developer has written several custom applications that read and write to the same Amazon DynamoDB table. Each time the data in the DynamoDB table is modified, this change should be sent to an external API.
 
@@ -1570,32 +1456,28 @@ Which combination of steps should the developer perform to accomplish this task?
 
 Report Content Errors
 
-A
-Configure an AWS Lambda function to poll the stream and call the external API.
+A Configure an AWS Lambda function to poll the stream and call the external API.
 
 Correct. If you enable DynamoDB Streams on a table, you can associate the stream Amazon Resource Name (ARN) with an Lambda function that you write. Immediately after an item in the table is modified, a new record appears in the table's stream. Lambda polls the stream and invokes your Lambda function synchronously when it detects new stream records.
 
 For more information about how to use DynamoDB Streams to create an event that invokes a Lambda function, see Tutorial: Process New Items with DynamoDB Streams and Lambda.
 
 
-B
-Configure an event in Amazon EventBridge (Amazon CloudWatch Events) that publishes the change to an Amazon Managed Streaming for Apache Kafka (Amazon MSK) data stream.
+B Configure an event in Amazon EventBridge (Amazon CloudWatch Events) that publishes the change to an Amazon Managed Streaming for Apache Kafka (Amazon MSK) data stream.
 
 Incorrect. EventBridge (CloudWatch Events) is used to connect applications with a variety of data. It would not be able to detect updates to a DynamoDB table.
 
 For more information about EventBridge (CloudWatch Events), see What Is Amazon EventBridge?
 
 
-C
-Create a trigger in the DynamoDB table to publish the change to an Amazon Kinesis data stream.
+C Create a trigger in the DynamoDB table to publish the change to an Amazon Kinesis data stream.
 
 Incorrect. A trigger cannot be enabled on a DynamoDB table. To create a trigger, a DynamoDB stream should be enabled on the specific DynamoDB table.
 
 For more information about how to use DynamoDB Streams to create an event that invokes an AWS Lambda function, see DynamoDB Streams and AWS Lambda Triggers.
 
 
-D
-Deliver the stream to an Amazon Simple Notification Service (Amazon SNS) topic and subscribe the API to the topic.
+D Deliver the stream to an Amazon Simple Notification Service (Amazon SNS) topic and subscribe the API to the topic.
 
 Incorrect. A DynamoDB stream cannot be used to create an Amazon SNS topic.
 
@@ -1606,8 +1488,7 @@ For more information about how Amazon SNS works, see What is Amazon SNS?
 For more information about how to create a topic in Amazon SNS, see Creating an Amazon SNS topic.
 
 
-E
-Enable DynamoDB Streams on the table.
+E Enable DynamoDB Streams on the table.
 
 Correct. You can enable DynamoDB Streams on a table to create an event that invokes an AWS Lambda function.
 
@@ -1622,12 +1503,9 @@ AE
 
 
  
-4.2 Migrate existing application code to run on AWS.
- This Question: 01:13
- Total: 21:50
+4.2 Migrate existing application code to run on AWS. This Question: 01:13 Total: 21:50
 
-17/20
-80.0% complete
+17/20 80.0% complete
  
 A company is migrating the create, read, update, and delete (CRUD) functionality of an existing Java web application to AWS Lambda.
 
@@ -1635,8 +1513,7 @@ Which minimal code refactoring is necessary for the CRUD operations to run in th
 
 Report Content Errors
 
-A
-Implement a Lambda handler function.
+A Implement a Lambda handler function.
 
 Correct. Every Lambda function needs a Lambda-specific handler. Specifics of authoring vary between runtimes, but all runtimes share a common programming model that defines the interface between your code and the runtime code. You tell the runtime which method to run by defining a handler in the function configuration. The runtime runs that method. Next, the runtime passes in objects to the handler that contain the invocation event and context, such as the function name and request ID.
 
@@ -1647,24 +1524,21 @@ For more information about Lambda features, see Lambda features.
 For more information about the Lambda handler function in Java, see AWS Lambda function handler in Java.
 
 
-B
-Import an AWS X-Ray package.
+B Import an AWS X-Ray package.
 
 Incorrect. Lambda is already integrated with X-Ray. Importing X-Ray is only needed for full instrumentation, which is optional and not part of the access control that is required by the scenario.
 
 For more information about X-Ray, see What is AWS X-Ray?
 
 
-C
-Rewrite the application code in Python.
+C Rewrite the application code in Python.
 
 Incorrect. Lambda supports Java, so you would not rewrite the code in Python. This solution would not meet the requirements of the question.
 
 For more information about the languages that Lambda supports, see AWS Lambda FAQs.
 
 
-D
-Add a reference to the Lambda execution role.
+D Add a reference to the Lambda execution role.
 
 Incorrect. The Lambda execution role is an IAM role that grants the function permission to access AWS services and resources. The Lambda execution role exists outside the application code, so it cannot be changed by refactoring the application code.
 
@@ -1679,12 +1553,9 @@ A
 
 
  
-5.1 Write code that can be monitored.
- This Question: 00:36
- Total: 22:26
+5.1 Write code that can be monitored. This Question: 00:36 Total: 22:26
 
-18/20
-85.0% complete
+18/20 85.0% complete
  
 A company plans to use AWS log monitoring services to monitor an application that runs on premises. Currently, the application runs on a recent version of Ubuntu Server and outputs the logs to a local file.
 
@@ -1692,40 +1563,35 @@ Which combination of steps should a developer perform to accomplish this goal? (
 
 Report Content Errors
 
-A
-Update the application code to include calls to the agent API for log collection.
+A Update the application code to include calls to the agent API for log collection.
 
 Incorrect. No update to the application code is necessary. The unified CloudWatch agent can be configured to read the local file for the log entries.
 
 For more information about collecting metrics and logs for on-premises servers with the CloudWatch agent, see Collecting metrics and logs from Amazon EC2 instances and on-premises servers with the CloudWatch agent.
 
 
-B
-Install the Amazon Elastic Container Service (Amazon ECS) container agent on the server.
+B Install the Amazon Elastic Container Service (Amazon ECS) container agent on the server.
 
 Incorrect. The ECS container agent allows container instances to connect to your cluster. You do not use it for monitoring the performance of the application code.
 
 For more information about the ECS container agent, see Amazon ECS container agent.
 
 
-C
-Install the unified Amazon CloudWatch agent on the server.
+C Install the unified Amazon CloudWatch agent on the server.
 
 Correct. The unified CloudWatch agent needs to be installed on the server. Ubuntu Server 18.04 is one of the many supported operating systems.
 
 For more information about collecting metrics and logs for on-premises servers with CloudWatch agent, see Collecting metrics and logs from Amazon EC2 instances and on-premises servers with the CloudWatch agent.
 
 
-D
-Configure the long-term AWS credentials on the server to enable log collection by the agent.
+D Configure the long-term AWS credentials on the server to enable log collection by the agent.
 
 Correct. When you install the unified CloudWatch agent on an on-premises server, you will specify a named profile that contains the credentials of the IAM user.
 
 For more information about collecting metrics and logs for on-premises servers with CloudWatch agent, see Collecting metrics and logs from Amazon EC2 instances and on-premises servers with the CloudWatch agent.
 
 
-E
-Attach an IAM role to the server to enable log collection by the agent.
+E Attach an IAM role to the server to enable log collection by the agent.
 
 Incorrect. You cannot attach an IAM role to an on-premises server. An IAM user, not an IAM role, provides credentials for an on-premises server. An IAM role provides server credentials for Amazon EC2 instances.
 
@@ -1740,12 +1606,9 @@ CD
 
 
  
-5.1 Write code that can be monitored.
- This Question: 01:13
- Total: 23:40
+5.1 Write code that can be monitored. This Question: 01:13 Total: 23:40
 
-19/20
-90.0% complete
+19/20 90.0% complete
  
 A developer wants to monitor invocations of an AWS Lambda function by using Amazon CloudWatch Logs. The developer added a number of print statements to the function code that write the logging information to the stdout stream. After running the function, the developer does not see any log data being generated.
 
@@ -1753,32 +1616,28 @@ Why does the log data NOT appear in the CloudWatch logs?
 
 Report Content Errors
 
-A
-The log data is not written to the stderr stream.
+A The log data is not written to the stderr stream.
 
 Incorrect. To output logs from your function code, you can use the print method or any logging library that writes to stdout or stderr.
 
 For more information about Lambda function logging, see AWS Lambda function logging in Python.
 
 
-B
-Lambda function logging is not automatically enabled.
+B Lambda function logging is not automatically enabled.
 
 Incorrect. Lambda automatically monitors Lambda functions and reports metrics through CloudWatch. Lambda automatically tracks the number of requests, the invocation duration per request, and the number of requests that result in an error.
 
 For more information about troubleshooting Lambda applications, see Monitoring and troubleshooting Lambda applications.
 
 
-C
-The execution role for the Lambda function did not grant permissions to write log data to CloudWatch Logs.
+C The execution role for the Lambda function did not grant permissions to write log data to CloudWatch Logs.
 
 Correct. The function needs permission to call CloudWatch Logs. Update the execution role to grant the permission. You can use the managed policy of AWSLambdaBasicExecutionRole.
 
 For more information about troubleshooting execution issues in Lambda, see Troubleshoot execution issues in Lambda.
 
 
-D
-The Lambda function outputs the logs to an Amazon S3 bucket.
+D The Lambda function outputs the logs to an Amazon S3 bucket.
 
 Incorrect. Lambda automatically stores logs generated by your code through CloudWatch Logs. You can view logs for Lambda functions by using the Lambda console, the CloudWatch console, the AWS CLI, or the CloudWatch API. You can transfer the logs from this CloudWatch log to an S3 bucket.
 
@@ -1795,12 +1654,9 @@ C
 
 
  
-5.2 Perform root cause analysis on faults found in testing or production.
- This Question: 00:29
- Total: 24:10
+5.2 Perform root cause analysis on faults found in testing or production. This Question: 00:29 Total: 24:10
 
-20/20
-95.0% complete
+20/20 95.0% complete
  
 A company notices performance degradation in one of its production web applications. The application is running on AWS services and uses a microservices architecture. The company suspects that one of these microservices is causing the performance issue.
 
@@ -1808,16 +1664,14 @@ Which AWS solution should the company use to identify the service that is contri
 
 Report Content Errors
 
-A
-AWS X-Ray service map
+A AWS X-Ray service map
 
 Correct. X-Ray creates a map of services used by your application with trace data. You can use the trace data to drill into specific services or issues. This data provides a view of connections between services in your application and aggregated data for each service, including average latency and failure rates.
 
 For more information about X-Ray, see AWS X-Ray features.
 
 
-B
-AWS CloudTrail event history
+B AWS CloudTrail event history
 
 Incorrect. CloudTrail event history is used to record API calls for governance, compliance operation, and risk auditing purposes. CloudTrail is not a service that is used for identifying application performance issues.
 
@@ -1826,8 +1680,7 @@ For more information about CloudTrail and its uses, see What Is AWS CloudTrail?
 For more information about CloudTrail event history, see Viewing Events with CloudTrail Event History.
 
 
-C
-Amazon EventBridge (Amazon CloudWatch Events) events
+C Amazon EventBridge (Amazon CloudWatch Events) events
 
 Incorrect. EventBridge (CloudWatch Events) delivers a near-real-time stream of system events that describe changes in Amazon Web Services resources. It is not used for identifying application performance issues.
 
@@ -1836,8 +1689,7 @@ For more information about EventBridge (CloudWatch Events), see What Is Amazon E
 For more information about EventBridge (CloudWatch Events) events, see Amazon EventBridge events.
 
 
-D
-AWS Trusted Advisor performance report
+D AWS Trusted Advisor performance report
 
 Incorrect. Trusted Advisor provides real-time guidance to help provision AWS resources to follow AWS best practices. It can report overall system utilization, but it is not used for identifying application performance issues.
 
@@ -1847,12 +1699,9 @@ For more information about Trusted Advisor, see AWS Trusted Advisor.
  
 # AWS 
  
-1.1 Design a multi-tier architecture solution
- This Question: 01:42
- Total: 01:42
+1.1 Design a multi-tier architecture solution This Question: 01:42 Total: 01:42
 
-1/20
-0.0% complete
+1/20 0.0% complete
  
 A solutions architect is designing a solution to run a containerized web application by using Amazon Elastic Container Service (Amazon ECS). The solutions architect wants to minimize cost by running multiple copies of a task on each container instance. The number of task copies must scale as the load increases and decreases.
 
@@ -1860,32 +1709,28 @@ Which routing solution distributes the load to the multiple tasks?
 
 Report Content Errors
 
-A
-Configure an Application Load Balancer to distribute the requests by using path-based routing.
+A Configure an Application Load Balancer to distribute the requests by using path-based routing.
 
 Incorrect. With path-based routing, multiple services can use the same listener port on a single Application Load Balancer (ALB). The ALB forwards requests to specific target groups based on the URL path. However, this solution does not help with load distribution between different tasks of the same service.
 
 For more information about load balancing, see Service load balancing.
 
 
-B
-Configure an Application Load Balancer to distribute the requests by using dynamic host port mapping.
+B Configure an Application Load Balancer to distribute the requests by using dynamic host port mapping.
 
 Correct. With dynamic host port mapping, multiple tasks from the same service are allowed for each container instance.
 
 For more information about load balancing, see Service load balancing.
 
 
-C
-Configure an Amazon Route 53 alias record set to distribute the requests with a failover routing policy.
+C Configure an Amazon Route 53 alias record set to distribute the requests with a failover routing policy.
 
 Incorrect. You can use failover routing policies to route traffic to backup instances, in case a primary instance fails. You cannot use failover routing policies to manage multiple tasks on a single container.
 
 For more information about routing policies, see Choosing a routing policy.
 
 
-D
-Configure an Amazon Route 53 alias record set to distribute the requests with a weighted routing policy.
+D Configure an Amazon Route 53 alias record set to distribute the requests with a weighted routing policy.
 
 Incorrect. You can use weighted routing policies to route traffic to instances at proportions that you specify. You cannot use weighted routing policies to manage multiple tasks on a single container.
 
@@ -1900,12 +1745,9 @@ B
 
 
  
-1.1 Design a multi-tier architecture solution
- This Question: 01:45
- Total: 03:28
+1.1 Design a multi-tier architecture solution This Question: 01:45 Total: 03:28
 
-2/20
-5.0% complete
+2/20 5.0% complete
  
 The usage of a company's image-processing application is increasing suddenly with no set pattern. The application's processing time grows linearly with the size of the image. The processing can take up to 20 minutes for large image files.
 
@@ -1915,8 +1757,7 @@ Which solution will meet these requirements?
 
 Report Content Errors
 
-A
-Purchase enough Dedicated Instances to meet the peak demand. Deploy the instances for the consumers.
+A Purchase enough Dedicated Instances to meet the peak demand. Deploy the instances for the consumers.
 
 Incorrect. With Dedicated Instances, you can reduce your costs by using existing server-bound software licenses. However, server-bound licenses are not mentioned in this scenario. One of the benefits of the AWS Cloud is that you do not have to purchase for peak consumption. The AWS Cloud can scale on demand.
 
@@ -1925,8 +1766,7 @@ For more information about Dedicated Hosts, see Amazon EC2 Dedicated Hosts Prici
 For more information about demand-based scaling, see Dynamic Supply.
 
 
-B
-Convert the existing SQS standard queue to an SQS FIFO queue. Increase the visibility timeout.
+B Convert the existing SQS standard queue to an SQS FIFO queue. Increase the visibility timeout.
 
 Incorrect. FIFO queues will solve problems that occur when messages are processed out of order. FIFO queues will not improve performance during sudden volume increases. Additionally, you cannot convert SQS queues after you create them.
 
@@ -1935,28 +1775,23 @@ For more information about FIFO queues, see Amazon SQS FIFO (First-In-First-Out)
 For more information about SQS queues, see Editing an Amazon SQS queue (console).
 
 
-C
-Configure a scalable AWS Lambda function as the consumer of the SQS messages.
+C Configure a scalable AWS Lambda function as the consumer of the SQS messages.
 
 Incorrect. Some files in this scenario can take up to 20 minutes to process. Lambda has a 15-minute operational limit.
 
 For more information about Lambda constraints, see Lambda quotas.
 
 
-D
-Create a message consumer that is an Auto Scaling group of instances. Configure the Auto Scaling group to scale based upon the ApproximateNumberOfMessages Amazon CloudWatch metric.
+D Create a message consumer that is an Auto Scaling group of instances. Configure the Auto Scaling group to scale based upon the ApproximateNumberOfMessages Amazon CloudWatch metric.
 
 Correct. With Amazon EC2 Auto Scaling, the processing capacity can keep up with the demand.
 
 For more information about the use of Amazon EC2 Auto Scaling with Amazon SQS, see Scaling based on Amazon SQS.
 
 
-1.2 Design highly available and/or fault-tolerant architectures
- This Question: 00:53
- Total: 04:21
+1.2 Design highly available and/or fault-tolerant architectures This Question: 00:53 Total: 04:21
 
-3/20
-10.0% complete
+3/20 10.0% complete
  
 An application runs on two Amazon EC2 instances behind a Network Load Balancer. The EC2 instances are in a single Availability Zone.
 
@@ -1964,32 +1799,28 @@ What should a solutions architect do to make this architecture more highly avail
 
 Report Content Errors
 
-A
-Create a new VPC with two new EC2 instances in the same Availability Zone as the original EC2 instances. Create a VPC peering connection between the two VPCs
+A Create a new VPC with two new EC2 instances in the same Availability Zone as the original EC2 instances. Create a VPC peering connection between the two VPCs
 
 Incorrect. VPC peering will provide connectivity to the other Availability Zone. However, VPC peering does not ensure high availability because the EC2 instances are still in one Availability Zone.
 
 For more information about VPC peering, see What is VPC Peering?
 
 
-B
-Replace the Network Load Balancer with an Application Load Balancer that is configured with the EC2 instances in an Auto Scaling group.
+B Replace the Network Load Balancer with an Application Load Balancer that is configured with the EC2 instances in an Auto Scaling group.
 
 Incorrect. The replacement of the Network Load Balancer with an Application Load Balancer provides no additional availability. Both load balancers are inherently highly available. However, the EC2 instances would be highly available only if they extended across two Availability Zones.
 
 For more information about Elastic Load Balancing, see How Elastic Load Balancing works.
 
 
-C
-Configure Amazon Route 53 to perform health checks on the EC2 instances behind the Network Load Balancer. Add a failover routing policy.
+C Configure Amazon Route 53 to perform health checks on the EC2 instances behind the Network Load Balancer. Add a failover routing policy.
 
 Incorrect. Failover routing requires a primary destination and a secondary (failover) destination. No failover destination is specified in this solution. In addition, this approach does not ensure high availability because the EC2 instances are still in one Availability Zone.
 
 For more information about DNS failover, see Configuring DNS failover.
 
 
-D
-Place the EC2 instances in an Auto Scaling group that extends across multiple Availability Zones. Designate the Auto Scaling group as the target of the Network Load Balancer.
+D Place the EC2 instances in an Auto Scaling group that extends across multiple Availability Zones. Designate the Auto Scaling group as the target of the Network Load Balancer.
 
 Correct. This solution extends the EC2 instances across multiple Availability Zones and automatically adds capacity when additional capacity is needed.
 
@@ -2004,12 +1835,9 @@ D
 
 
  
-1.4 Choose appropriate resilient storage
- This Question: 00:56
- Total: 05:17
+1.4 Choose appropriate resilient storage This Question: 00:56 Total: 05:17
 
-4/20
-15.0% complete
+4/20 15.0% complete
  
 A company is using an Amazon S3 bucket to store legal documents. The company frequently revises the documents and re-uploads them with the same object key to the S3 bucket. The company needs the ability to download older copies of the documents. The company also needs to protect the documents from accidental deletion.
 
@@ -2017,32 +1845,28 @@ What is the MOST operationally efficient solution that meets these requirements?
 
 Report Content Errors
 
-A
-Enable S3 Versioning on the S3 bucket.
+A Enable S3 Versioning on the S3 bucket.
 
 Correct. With S3 Versioning, you can keep multiple variants of an object in the same S3 bucket. You can use S3 Versioning to preserve, retrieve, and restore every version of every object that is stored in your S3 bucket. By using S3 Versioning, you can recover from unintended user actions and application failures.
 
 For more information about S3 Versioning, see How S3 Versioning works.
 
 
-B
-Enable multi-factor authentication (MFA) delete on the S3 bucket.
+B Enable multi-factor authentication (MFA) delete on the S3 bucket.
 
 Incorrect. MFA delete provides an additional layer of object security. MFA delete ensures that the entity that deletes the objects possesses an authorized MFA token. However, MFA delete does not meet the document versioning requirements of this question.
 
 For more information about MFA delete, see Configuring MFA delete.
 
 
-C
-Configure S3 Cross-Region Replication from the S3 bucket to an S3 bucket in a different AWS Region.
+C Configure S3 Cross-Region Replication from the S3 bucket to an S3 bucket in a different AWS Region.
 
 Incorrect. S3 Cross-Region Replication requires S3 Versioning as a prerequisite. However, S3 Versioning alone meets the requirements of this question and is the more operationally efficient solution.
 
 For information about S3 Cross-Region Replication, see Replicating objects.
 
 
-D
-Configure an S3 Lifecycle policy to archive the documents to S3 Glacier after 30 days.
+D Configure an S3 Lifecycle policy to archive the documents to S3 Glacier after 30 days.
 
 Incorrect. You can use S3 Lifecycle rules to store objects cost-effectively throughout their lifecycle. S3 Lifecycle rules do not meet the document versioning requirements of this question.
 
@@ -2057,12 +1881,9 @@ A
 
 
  
-2.1 Identify elastic and scalable compute solutions for a workload
- This Question: 00:50
- Total: 06:07
+2.1 Identify elastic and scalable compute solutions for a workload This Question: 00:50 Total: 06:07
 
-5/20
-20.0% complete
+5/20 20.0% complete
  
 A reporting application runs on Amazon EC2 instances behind an Application Load Balancer. The instances run in an Amazon EC2 Auto Scaling group across multiple Availability Zones. For complex reports, the application can take up to 15 minutes to respond to a request. A solutions architect is concerned that users will receive HTTP 5xx errors if a report request is in process during a scale-in event.
 
@@ -2070,32 +1891,28 @@ What should the solutions architect do to ensure that user requests will be comp
 
 Report Content Errors
 
-A
-Enable sticky sessions (session affinity) for the target group of the instances.
+A Enable sticky sessions (session affinity) for the target group of the instances.
 
 Incorrect. If an EC2 instance were removed from the target group during a scale-in process, the EC2 instance would fail (or would be unhealthy if it were checked). An Application Load Balancer would stop routing requests to that target and would choose a new healthy target.
 
 For more information about sticky sessions, see Sticky sessions for your Application Load Balancer.
 
 
-B
-Increase the instance size in the Application Load Balancer target group.
+B Increase the instance size in the Application Load Balancer target group.
 
 Incorrect. An increase of the instance size likely would increase the speed of processing. However, this solution does not directly ensure that instances that process a request are unaffected by scale-in actions.
 
 For more information about deregistration delay, see Deregistration delay.
 
 
-C
-Increase the cooldown period for the Auto Scaling group to a greater amount of time than the time required for the longest running responses.
+C Increase the cooldown period for the Auto Scaling group to a greater amount of time than the time required for the longest running responses.
 
 Incorrect. Amazon EC2 Auto Scaling cooldown periods help you prevent Auto Scaling groups from launching or terminating additional instances before the effects of previous activities are apparent.
 
 For more information about cooldown periods, see Scaling cooldowns for Amazon EC2 Auto Scaling.
 
 
-D
-Increase the deregistration delay timeout for the target group of the instances to greater than 900 seconds.
+D Increase the deregistration delay timeout for the target group of the instances to greater than 900 seconds.
 
 Correct. By default, Elastic Load Balancing waits 300 seconds before the completion of the deregistration process, which can help in-flight requests to the target become complete. To change the amount of time that Elastic Load Balancing waits, update the deregistration delay value.
 
@@ -2110,12 +1927,9 @@ D
 
 
  
-2.1 Identify elastic and scalable compute solutions for a workload
- This Question: 00:39
- Total: 06:47
+2.1 Identify elastic and scalable compute solutions for a workload This Question: 00:39 Total: 06:47
 
-6/20
-25.0% complete
+6/20 25.0% complete
  
 A company used Amazon EC2 Spot Instances for a demonstration that is now complete. A solutions architect must remove the Spot Instances to stop them from incurring cost.
 
@@ -2123,32 +1937,28 @@ What should the solutions architect do to meet this requirement?
 
 Report Content Errors
 
-A
-Cancel the Spot request only.
+A Cancel the Spot request only.
 
 Incorrect. If the only action you take is to cancel the Spot request, the running instances will not be terminated automatically. These instances will continue to run and will incur additional cost.
 
 For more information about the termination of Spot Instances, see Terminate a Spot Instance.
 
 
-B
-Terminate the Spot Instances only.
+B Terminate the Spot Instances only.
 
 Incorrect. When Spot Instances are terminated, new instances will launch until the Spot request is canceled.
 
 For more information about the termination of Spot Instances, see Terminate a Spot Instance.
 
 
-C
-Cancel the Spot request. Terminate the Spot Instances.
+C Cancel the Spot request. Terminate the Spot Instances.
 
 Correct. To remove the Spot Instances, the appropriate steps are to cancel the Spot request and then to terminate the Spot Instances.
 
 For more information about the termination of Spot Instances, see Terminate a Spot Instance.
 
 
-D
-Terminate the Spot Instances. Cancel the Spot request.
+D Terminate the Spot Instances. Cancel the Spot request.
 
 Incorrect. When Spot Instances are terminated, new instances will launch until the Spot request is canceled.
 
@@ -2163,12 +1973,9 @@ C
 
 
  
-2.1 Identify elastic and scalable compute solutions for a workload
- This Question: 00:41
- Total: 07:28
+2.1 Identify elastic and scalable compute solutions for a workload This Question: 00:41 Total: 07:28
 
-7/20
-30.0% complete
+7/20 30.0% complete
  
 A company needs to look up configuration details about how a Linux-based Amazon EC2 instance was launched.
 
@@ -2176,32 +1983,28 @@ Which command should a solutions architect run on the EC2 instance to gather the
 
 Report Content Errors
 
-A
-curl http://169.254.169.254/latest/meta-data
+A curl http://169.254.169.254/latest/meta-data
 
 Correct. The only way to retrieve instance metadata is to use the link-local address, which is 169.254.169.254.
 
 For more information about instance metadata, see Retrieve instance metadata.
 
 
-B
-curl http://localhost/latest/meta-data
+B curl http://localhost/latest/meta-data
 
 Incorrect. The use of localhost will not work because this solution checks an IP address of 127.0.0.1. Metadata is not available through the use of the localhost name.
 
 For more information about instance metadata, see Retrieve instance metadata.
 
 
-C
-curl http://254.169.254.169/latest/meta-data
+C curl http://254.169.254.169/latest/meta-data
 
 Incorrect. The format for the link-local address is 169.254.169.254.
 
 For more information about instance metadata, see Retrieve instance metadata.
 
 
-D
-curl http://192.168.0.1/latest/meta-data
+D curl http://192.168.0.1/latest/meta-data
 
 Incorrect. The 192.168.x.x. IP address range is a public block. Instance metadata is not available through a public block.
 
@@ -2216,12 +2019,9 @@ A
 
 
  
-2.2 Select high-performing and scalable storage solutions for a workload
- This Question: 01:00
- Total: 08:29
+2.2 Select high-performing and scalable storage solutions for a workload This Question: 01:00 Total: 08:29
 
-8/20
-35.0% complete
+8/20 35.0% complete
  
 A company has an on-premises application that exports log files about users of a website. These log files range from 20 GB to 30 GB in size. A solutions architect has created an Amazon S3 bucket to store these files. The files will be uploaded directly from the application. The network connection experiences intermittent failures, and the upload sometimes fails.
 
@@ -2231,32 +2031,28 @@ Which solution will meet these requirements?
 
 Report Content Errors
 
-A
-Enable S3 Transfer Acceleration.
+A Enable S3 Transfer Acceleration.
 
 Incorrect. S3 Transfer Acceleration facilitates quicker uploads by using edge locations to copy data into Amazon S3. S3 Transfer Acceleration does not solve the problem of the file size limitation (5 GB) for a single PUT operation.
 
 For more information about S3 Transfer Acceleration, see S3 Transfer Acceleration.
 
 
-B
-Copy the files to an Amazon EC2 instance in the closest AWS Region. Use S3 Lifecycle policies to copy the log files to Amazon S3.
+B Copy the files to an Amazon EC2 instance in the closest AWS Region. Use S3 Lifecycle policies to copy the log files to Amazon S3.
 
 Incorrect. This solution does not solve the problem of the file size limitation (5 GB) for a single PUT operation. S3 Lifecycle policies cannot transfer files from EC2 block storage to Amazon S3. This solution also adds unnecessary services and operational overhead to the environment.
 
 For more information about Amazon EC2, see What is Amazon EC2?
 
 
-C
-Use multipart upload to Amazon S3.
+C Use multipart upload to Amazon S3.
 
 Correct. With a single PUT operation, you can upload a single object that is up to 5 GB in size. You can use a multipart upload to upload larger files, such as the files in this scenario.
 
 For more information about multipart uploads, see Uploading and copying objects using multipart upload.
 
 
-D
-Upload the files to two AWS Regions simultaneously. Enable two-way Cross-Region Replication between the two Regions.
+D Upload the files to two AWS Regions simultaneously. Enable two-way Cross-Region Replication between the two Regions.
 
 Incorrect. This solution does not solve the problem of the file size limitation (5 GB) for a single PUT operation. Each destination Region would have the same problem as a single Region. This solution also adds operational overhead.
 
@@ -2271,12 +2067,9 @@ C
 
 
  
-2.2 Select high-performing and scalable storage solutions for a workload
- This Question: 00:27
- Total: 08:56
+2.2 Select high-performing and scalable storage solutions for a workload This Question: 00:27 Total: 08:56
 
-9/20
-40.0% complete
+9/20 40.0% complete
  
 A company is deploying a new database on a new Amazon EC2 instance. The workload of this database requires a single Amazon Elastic Block Store (Amazon EBS) volume that can support up to 20,000 IOPS.
 
@@ -2284,32 +2077,28 @@ Which type of EBS volume meets this requirement?
 
 Report Content Errors
 
-A
-Throughput Optimized HDD
+A Throughput Optimized HDD
 
 Incorrect. A Throughput Optimized HDD EBS volume is an HDD-backed storage device that is limited to 500 IOPS for each volume.
 
 For more information about Throughput Optimized HDD EBS volumes, see Hard disk drives (HDD).
 
 
-B
-Provisioned IOPS SSD
+B Provisioned IOPS SSD
 
 Correct. A Provisioned IOPS SSD EBS volume provides up to 64,000 IOPS for each volume.
 
 For more information about Provisioned IOPS SSD EBS volumes, see Solid state drives (SSD).
 
 
-C
-General Purpose SSD
+C General Purpose SSD
 
 Incorrect. A General Purpose SSD EBS volume is limited to 16,000 IOPS for each volume.
 
 For more information about General Purpose SSD EBS volumes, see Solid state drives (SSD).
 
 
-D
-Cold HDD
+D Cold HDD
 
 Incorrect. A Cold HDD volume provides low-cost magnetic storage that defines performance in terms of throughput rather than IOPS. Cold HDD volumes are a good fit for large, sequential cold-data workloads.
 
@@ -2324,27 +2113,22 @@ B
 
 
  
-2.3 Select high-performing networking solutions for a workload
- This Question: 00:29
- Total: 09:26
+2.3 Select high-performing networking solutions for a workload This Question: 00:29 Total: 09:26
 
-10/20
-45.0% complete
+10/20 45.0% complete
  
 Which components are required to build a site-to-site VPN connection on AWS? (Select TWO.)
 
 Report Content Errors
 
-A
-An internet gateway
+A An internet gateway
 
 Incorrect. An internet gateway is attached to a VPC to allow traffic from the internet to flow into or out of the VPC. A VPN connection does not flow through an internet gateway. The internet gateway is designed to allow traffic from the open internet, not an encrypted VPN connection.
 
 For more information about internet gateways, see Internet gateways.
 
 
-B
-A NAT gateway
+B A NAT gateway
 
 Incorrect. A NAT gateway provides a way for private Amazon EC2 instances to send requests to the internet. A NAT gateway does not give you the ability to create an encrypted site-to-site VPN connection.
 
@@ -2353,24 +2137,21 @@ For more information about NAT gateways, see NAT gateways.
 For more information about VPN connections to AWS, see What is AWS Site-to-Site VPN?
 
 
-C
-A customer gateway
+C A customer gateway
 
 Correct. A customer gateway is required for the VPN connection to be established. A customer gateway device is set up and configured in the customer's data center.
 
 For more information about customer gateways and VPN connections to AWS, see What is AWS Site-to-Site VPN?
 
 
-D
-Amazon API Gateway
+D Amazon API Gateway
 
 Incorrect. API Gateway is a fully managed service for developers to create, publish, maintain, monitor, and secure APIs at any scale. APIs act as the front door for applications to use to access data, business logic, or functionality from backend services. However, API Gateway is not necessary for the implementation of a VPN connection.
 
 For more information about API Gateway, see What is Amazon API Gateway?
 
 
-E
-A virtual private gateway
+E A virtual private gateway
 
 Correct. A virtual private gateway is attached to a VPC to create a site-to-site VPN connection on AWS. You can accept private encrypted network traffic from an on-premises data center into your VPC without the need to traverse the open public internet.
 
@@ -2385,12 +2166,9 @@ CE
 
 
  
-2.4 Choose high-performing database solutions for a workload
- This Question: 00:35
- Total: 10:02
+2.4 Choose high-performing database solutions for a workload This Question: 00:35 Total: 10:02
 
-11/20
-50.0% complete
+11/20 50.0% complete
  
 A company is developing a chat application that will be deployed on AWS. The application stores the messages by using a key-value data model. Groups of users typically read the messages multiple times. A solutions architect must select a database solution that will scale for a high rate of reads and will deliver messages with microsecond latency.
 
@@ -2398,16 +2176,14 @@ Which database solution will meet these requirements?
 
 Report Content Errors
 
-A
-Amazon Aurora with Aurora Replicas
+A Amazon Aurora with Aurora Replicas
 
 Incorrect. Aurora is a relational database (not a key-value database). Aurora is not likely to achieve microsecond latency consistently.
 
 For more information about Aurora, see What is Amazon Aurora?
 
 
-B
-Amazon DynamoDB with DynamoDB Accelerator (DAX)
+B Amazon DynamoDB with DynamoDB Accelerator (DAX)
 
 Correct. DynamoDB is a NoSQL database that supports key-value records. DAX delivers response times in microseconds.
 
@@ -2416,8 +2192,7 @@ For more information about DynamoDB, see What is Amazon DynamoDB?
 For more information about DAX, see In-Memory Acceleration with DynamoDB Accelerator (DAX).
 
 
-C
-Amazon Aurora with Amazon ElastiCache for Memcached
+C Amazon Aurora with Amazon ElastiCache for Memcached
 
 Incorrect. Aurora is a relational database (not a key-value database). Aurora is not likely to achieve microsecond latency consistently, even with ElastiCache.
 
@@ -2426,8 +2201,7 @@ For more information about Aurora, see What is Amazon Aurora?
 For more information about ElastiCache for Memcached, see What is Amazon ElastiCache for Memcached?
 
 
-D
-Amazon Neptune with Amazon ElastiCache for Memcached
+D Amazon Neptune with Amazon ElastiCache for Memcached
 
 Incorrect. Neptune is a graph database that is optimized for working with highly connected data. Neptune is not optimized for simple key-value data.
 
@@ -2442,12 +2216,9 @@ B
 
 
  
-3.1 Design secure access to AWS resources
- This Question: 00:57
- Total: 11:00
+3.1 Design secure access to AWS resources This Question: 00:57 Total: 11:00
 
-12/20
-55.0% complete
+12/20 55.0% complete
  
 A company uses one AWS account to run production workloads. The company has a separate AWS account for its security team. During periodic audits, the security team needs to view specific account settings and resource configurations in the AWS account that runs production workloads. A solutions architect must provide the required access to the security team by designing a solution that follows AWS security best practices.
 
@@ -2455,32 +2226,28 @@ Which solution will meet these requirements?
 
 Report Content Errors
 
-A
-Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to each user.
+A Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to each user.
 
 Incorrect. This solution does not follow the security best practice of using roles to delegate permissions.
 
 For more information about how to use roles to delegate permissions, see Use roles to delegate permissions.
 
 
-B
-Create an IAM role in the production account. Attach a permissions policy that provides the permissions required by the security team. Add the security team account to the trust policy.
+B Create an IAM role in the production account. Attach a permissions policy that provides the permissions required by the security team. Add the security team account to the trust policy.
 
 Correct. This solution follows security best practices by using a role to delegate permissions that consist of least privilege access.
 
 For more information about how to use roles to delegate permissions, see Use roles to delegate permissions.
 
 
-C
-Create a new IAM user in the production account. Assign administrative privileges to the user. Allow the security team to use this account to log in to the systems that need to be accessed.
+C Create a new IAM user in the production account. Assign administrative privileges to the user. Allow the security team to use this account to log in to the systems that need to be accessed.
 
 Incorrect. The assignment of administrative privileges to a user violates security best practices and the principle of least privilege.
 
 For more information about how to grant least privilege in roles, see Grant least privilege.
 
 
-D
-Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to a new IAM group. Assign the security team members to the group.
+D Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to a new IAM group. Assign the security team members to the group.
 
 Incorrect. This solution does not follow the security best practice of using roles to delegate permissions.
 
@@ -2495,12 +2262,9 @@ B
 
 
  
-3.1 Design secure access to AWS resources
- This Question: 00:31
- Total: 11:31
+3.1 Design secure access to AWS resources This Question: 00:31 Total: 11:31
 
-13/20
-60.0% complete
+13/20 60.0% complete
  
 A company is developing a new mobile version of its popular web application in the AWS Cloud. The mobile app must be accessible to internal and external users. The mobile app must handle authorization, authentication, and user management from one central source.
 
@@ -2508,16 +2272,14 @@ Which solution meets these requirements?
 
 Report Content Errors
 
-A
-IAM roles
+A IAM roles
 
 Incorrect. An IAM role is an IAM entity that is assumable by an IAM user. An IAM role has permissions policies that define what the entity can and cannot do. However, an IAM role does not control access to an application.
 
 For more information about IAM roles, see IAM roles.
 
 
-B
-IAM users and groups
+B IAM users and groups
 
 Incorrect. You can use IAM users and groups to control who is authenticated and authorized to use an AWS service. However, users and groups do not control access to an application.
 
@@ -2526,16 +2288,14 @@ For more information about IAM users, see IAM users.
 For more information about IAM groups, see IAM groups.
 
 
-C
-Amazon Cognito user pools
+C Amazon Cognito user pools
 
 Correct. Amazon Cognito provides authentication, authorization, and user management for your web and mobile apps. Users can sign in directly with a user name and password, or through a trusted third party.
 
 For more information about Amazon Cognito, see What is Amazon Cognito?
 
 
-D
-AWS Security Token Service (AWS STS)
+D AWS Security Token Service (AWS STS)
 
 Incorrect. You can use AWS STS to create and provide trusted users with temporary security credentials that can control access to your AWS resources. However, AWS STS does not control access to an application.
 
@@ -2550,12 +2310,9 @@ C
 
 
  
-3.2 Design secure application tiers
- This Question: 00:58
- Total: 12:29
+3.2 Design secure application tiers This Question: 00:58 Total: 12:29
 
-14/20
-65.0% complete
+14/20 65.0% complete
  
 A company has strict data protection requirements. A solutions architect must configure security for a VPC to ensure that backend Amazon RDS DB instances cannot be accessed from the internet. The solutions architect must ensure that the DB instances are accessible from the application tier over a specified port only.
 
@@ -2563,40 +2320,35 @@ Which actions should the solutions architect take to meet these requirements? (S
 
 Report Content Errors
 
-A
-Specify a DB subnet group that contains only private subnets for the DB instances.
+A Specify a DB subnet group that contains only private subnets for the DB instances.
 
 Correct. A private subnet is one component to use to secure the database tier. Internet traffic is not routed to a private subnet. When you place DB instances in a private subnet, you add a layer of security.
 
 For more information about VPCs with public subnets and private subnets, see Routing.
 
 
-B
-Attach an elastic network interface with a private IPv4 address to each DB instance.
+B Attach an elastic network interface with a private IPv4 address to each DB instance.
 
 Incorrect. An elastic network interface is a logical networking component in a VPC that represents a virtual network card. The use of an elastic network interface would not meet the requirements in the scenario.
 
 For more information about elastic network interfaces, see Elastic network interfaces.
 
 
-C
-Configure AWS Shield with the VPC. Update the route tables for the subnets that the DB instances use.
+C Configure AWS Shield with the VPC. Update the route tables for the subnets that the DB instances use.
 
 Incorrect. Shield provides protection against DDoS attacks. Shield cannot be a target of routes in a route table. The use of Shield would not meet the requirements in the scenario.
 
 For more information about Shield, see AWS Shield.
 
 
-D
-Configure an AWS Direct Connect connection on the database port between the application tier and the backend.
+D Configure an AWS Direct Connect connection on the database port between the application tier and the backend.
 
 Incorrect. Direct Connect provides a dedicated connection to your AWS environment. The use of Direct Connect would not meet the requirements in the scenario.
 
 For more information about Direct Connect, see AWS Direct Connect features.
 
 
-E
-Add an inbound rule to the database security group that allows requests from the security group of the application tier over the database port. Remove other inbound rules.
+E Add an inbound rule to the database security group that allows requests from the security group of the application tier over the database port. Remove other inbound rules.
 
 Correct. Security groups can restrict access to the DB instances. Security groups provide access from only the application tier on only a specific port.
 
@@ -2611,12 +2363,9 @@ AE
 
 
  
-3.3 Select appropriate data security options
- This Question: 01:00
- Total: 13:30
+3.3 Select appropriate data security options This Question: 01:00 Total: 13:30
 
-15/20
-70.0% complete
+15/20 70.0% complete
  
 A company runs its website on Amazon EC2 instances behind an Application Load Balancer that is configured as the origin for an Amazon CloudFront distribution. The company wants to protect against cross-site scripting and SQL injection attacks.
 
@@ -2624,32 +2373,28 @@ Which approach should a solutions architect recommend to meet these requirements
 
 Report Content Errors
 
-A
-Enable AWS Shield Advanced. List the CloudFront distribution as a protected resource.
+A Enable AWS Shield Advanced. List the CloudFront distribution as a protected resource.
 
 Incorrect. Shield Advanced protects against DDoS attacks. Shield Advanced does not protect against cross-site scripting or SQL injection.
 
 For more information about Shield Advanced, see AWS Shield.
 
 
-B
-Define an AWS Shield Advanced policy in AWS Firewall Manager to block cross-site scripting and SQL injection attacks.
+B Define an AWS Shield Advanced policy in AWS Firewall Manager to block cross-site scripting and SQL injection attacks.
 
 Incorrect. With Firewall Manager, you can manage AWS WAF, Shield Advanced, and other AWS services. Shield Advanced protects against DDoS attacks. Shield Advanced does not protect against cross-site scripting or SQL injection.
 
 For more information about AWS WAF, AWS Shield, and Firewall Manager, see What are AWS WAF, AWS Shield, and AWS Firewall Manager?
 
 
-C
-Set up AWS WAF on the CloudFront distribution. Use conditions and rules that block cross-site scripting and SQL injection attacks.
+C Set up AWS WAF on the CloudFront distribution. Use conditions and rules that block cross-site scripting and SQL injection attacks.
 
 Correct. AWS WAF can detect the presence of SQL code that is likely to be malicious (known as SQL injection). AWS WAF also can detect the presence of a script that is likely to be malicious (known as cross-site scripting).
 
 For more information about AWS WAF, see AWS WAF.
 
 
-D
-Deploy AWS Firewall Manager on the EC2 instances. Create conditions and rules that block cross-site scripting and SQL injection attacks.
+D Deploy AWS Firewall Manager on the EC2 instances. Create conditions and rules that block cross-site scripting and SQL injection attacks.
 
 Incorrect. With Firewall Manager, you can manage AWS WAF, AWS Shield Advanced, and other AWS services. Firewall Manager is a managed service that is not installed on EC2 instances.
 
@@ -2664,12 +2409,9 @@ C
 
 
  
-4.1 Identify cost-effective storage solutions
- This Question: 01:19
- Total: 14:50
+4.1 Identify cost-effective storage solutions This Question: 01:19 Total: 14:50
 
-16/20
-75.0% complete
+16/20 75.0% complete
  
 A solutions architect is planning a company's migration to the AWS Cloud. A key component of the company's environment is an application server that sends email notifications to customers. As part of this migration, the solutions architect must use only managed AWS services.
 
@@ -2677,32 +2419,28 @@ Which solution meets these requirements?
 
 Report Content Errors
 
-A
-Configure Amazon Simple Queue Service (Amazon SQS) with a standard queue.
+A Configure Amazon Simple Queue Service (Amazon SQS) with a standard queue.
 
 Incorrect. Amazon SQS is a fully managed message queuing service that sends messages between software components. However, Amazon SQS cannot push messages to customers.
 
 For information about Amazon SQS, see Amazon Simple Queue Service.
 
 
-B
-Deploy an Amazon EC2 instance to host the application server. Send email notifications.
+B Deploy an Amazon EC2 instance to host the application server. Send email notifications.
 
 Incorrect. The deployment of an EC2 instance gives the company the ability to run its application. However, this solution does not use only managed services.
 
 For more information about Amazon EC2, see Amazon EC2.
 
 
-C
-Configure Amazon Simple Queue Service (Amazon SQS) with a FIFO queue.
+C Configure Amazon Simple Queue Service (Amazon SQS) with a FIFO queue.
 
 Incorrect. Amazon SQS is a fully managed message queuing service that sends messages between software components. However, Amazon SQS cannot push messages to customers.
 
 For information about Amazon SQS, see Amazon Simple Queue Service.
 
 
-D
-Configure Amazon Simple Notification Service (Amazon SNS) with the protocol of email.
+D Configure Amazon Simple Notification Service (Amazon SNS) with the protocol of email.
 
 Correct. Amazon SNS is a fully managed messaging service for application-to-application communication and application-to-person communication.
 
@@ -2717,12 +2455,9 @@ D
 
 
  
-4.1 Identify cost-effective storage solutions
- This Question: 00:42
- Total: 15:32
+4.1 Identify cost-effective storage solutions This Question: 00:42 Total: 15:32
 
-17/20
-80.0% complete
+17/20 80.0% complete
  
 A company needs to maintain data records for a minimum of 5 years. The data is rarely accessed after it is stored. The data must be accessible within 2 hours.
 
@@ -2730,16 +2465,14 @@ Which solution will meet these requirements MOST cost-effectively?
 
 Report Content Errors
 
-A
-Store the data in an Amazon Elastic File System (Amazon EFS) file system. Access the data by using AWS Direct Connect.
+A Store the data in an Amazon Elastic File System (Amazon EFS) file system. Access the data by using AWS Direct Connect.
 
 Incorrect. This solution is not the most cost-effective solution. Amazon S3 is a more cost-effective solution if there is not a requirement for a file system.
 
 For more information about Amazon EFS and Direct Connect, see How Amazon EFS works with AWS Direct Connect and AWS Managed VPN.
 
 
-B
-Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Glacier.
+B Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Glacier.
 
 Correct. The storage of the data in an S3 bucket provides a cost-effective initial location for the data. S3 Glacier is the most cost-effective archival storage solution that meets the requirement of a 2-hour retrieval time.
 
@@ -2748,16 +2481,14 @@ For more information about how to move data between S3 storage classes automatic
 For more information about S3 storage classes, see Using Amazon S3 storage classes.
 
 
-C
-Store the data in an Amazon Elastic Block Store (Amazon EBS) volume. Create snapshots. Store the snapshots in an Amazon S3 bucket.
+C Store the data in an Amazon Elastic Block Store (Amazon EBS) volume. Create snapshots. Store the snapshots in an Amazon S3 bucket.
 
 Incorrect. This solution is not the most cost-effective solution because it requires the use of Amazon EBS in addition to Amazon S3.
 
 For more information about EBS snapshots, see Amazon EBS snapshots.
 
 
-D
-Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Standard-Infrequent Access (S3 Standard-IA).
+D Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Standard-Infrequent Access (S3 Standard-IA).
 
 Incorrect. The storage of the data in an S3 bucket provides a cost-effective initial location for the data. However, S3 Standard-IA is not the most cost-effective storage class to meet the requirements in the scenario. The S3 Glacier storage class is designed for low-cost data archiving.
 
@@ -2772,12 +2503,9 @@ B
 
 
  
-4.1 Identify cost-effective storage solutions
- This Question: 00:42
- Total: 16:15
+4.1 Identify cost-effective storage solutions This Question: 00:42 Total: 16:15
 
-18/20
-85.0% complete
+18/20 85.0% complete
  
 A media company is designing a new solution for graphic rendering. The application requires up to 400 GB of storage for temporary data that is discarded after the frames are rendered. The application requires approximately 40,000 random IOPS to perform the rendering.
 
@@ -2785,16 +2513,14 @@ What is the MOST cost-effective storage option for this rendering application?
 
 Report Content Errors
 
-A
-A storage optimized Amazon EC2 instance with instance store storage
+A A storage optimized Amazon EC2 instance with instance store storage
 
 Correct. SSD-Backed Storage Optimized (i2) instances provide more than 365,000 random IOPS. The instance store has no additional cost, compared with the regular hourly cost of the instance.
 
 For more information about pricing for EC2 instances, see Amazon EC2 pricing.
 
 
-B
-A storage optimized Amazon EC2 instance with a Provisioned IOPS SSD (io1 or io2) Amazon Elastic Block Store (Amazon EBS) volume
+B A storage optimized Amazon EC2 instance with a Provisioned IOPS SSD (io1 or io2) Amazon Elastic Block Store (Amazon EBS) volume
 
 Incorrect. Provisioned IOPS SSD (io1 or io2) EBS volumes can deliver more than the 40,000 IOPS that are required in the scenario. However, this solution is not as cost-effective as an instance store because Amazon EBS adds cost to the hourly instance rate. This solution provides persistence of data beyond the lifecycle of the instance, but persistence is not required in this use case.
 
@@ -2803,8 +2529,7 @@ For more information about Provisioned IOPS SSD (io1 or io2) EBS volumes, see Pr
 For more information about pricing for Amazon EBS, see Amazon EBS pricing.
 
 
-C
-A burstable Amazon EC2 instance with a Throughput Optimized HDD (st1) Amazon Elastic Block Store (Amazon EBS) volume
+C A burstable Amazon EC2 instance with a Throughput Optimized HDD (st1) Amazon Elastic Block Store (Amazon EBS) volume
 
 Incorrect. Throughput Optimized HDD (st1) EBS volumes are engineered to maximize the throughput of data that can be sent to and from a volume, not the random IOPS. Consequently, this solution does not meet the IOPS requirement. In addition, Amazon EBS adds cost to the hourly instance rate. This solution provides persistence of data beyond the lifecycle of the instance, but persistence is not required in this use case.
 
@@ -2813,8 +2538,7 @@ For more information about Throughput Optimized HDD (st1) EBS volumes, see Throu
 For more information about pricing for Amazon EBS, see Amazon EBS pricing.
 
 
-D
-A burstable Amazon EC2 instance with Amazon S3 storage over a VPC endpoint
+D A burstable Amazon EC2 instance with Amazon S3 storage over a VPC endpoint
 
 Incorrect. The rapidly changing data that is required for the scratch volume space makes Amazon S3 (object storage) the wrong storage. Block storage is appropriate for the read/write functionality to work smoothly.
 
@@ -2827,12 +2551,9 @@ A
 
 
  
-4.2 Identify cost-effective compute and database services
- This Question: 01:00
- Total: 17:15
+4.2 Identify cost-effective compute and database services This Question: 01:00 Total: 17:15
 
-19/20
-90.0% complete
+19/20 90.0% complete
  
 A company is deploying a new application that will consist of an application layer and an online transaction processing (OLTP) relational database. The application must be available at all times. However, the application will have periods of inactivity. The company wants to pay the minimum for compute costs during these idle periods.
 
@@ -2840,8 +2561,7 @@ Which solution meets these requirements MOST cost-effectively?
 
 Report Content Errors
 
-A
-Run the application in containers with Amazon Elastic Container Service (Amazon ECS) on AWS Fargate. Use Amazon Aurora Serverless for the database.
+A Run the application in containers with Amazon Elastic Container Service (Amazon ECS) on AWS Fargate. Use Amazon Aurora Serverless for the database.
 
 Correct. When Amazon ECS uses Fargate for compute, it incurs no costs when the application is idle. Aurora Serverless also incurs no compute costs when it is idle.
 
@@ -2850,24 +2570,21 @@ For more information about Fargate, see AWS Fargate Pricing.
 For more information about Aurora Serverless, see Amazon Aurora Serverless.
 
 
-B
-Run the application on Amazon EC2 instances by using a burstable instance type. Use Amazon Redshift for the database.
+B Run the application on Amazon EC2 instances by using a burstable instance type. Use Amazon Redshift for the database.
 
 Incorrect. EC2 burstable instances offer burstable capability without scaling. However, this solution does not minimize cost during the periods of inactivity and is not the most cost-effective option. In addition, an Amazon Redshift database is not ideal for OLTP. Amazon Redshift is specifically designed for online analytic processing (OLAP).
 
 For more information about Amazon Redshift, see What is Amazon Redshift?
 
 
-C
-Deploy the application and a MySQL database to Amazon EC2 instances by using AWS CloudFormation. Delete the stack at the beginning of the idle periods.
+C Deploy the application and a MySQL database to Amazon EC2 instances by using AWS CloudFormation. Delete the stack at the beginning of the idle periods.
 
 Incorrect. Although infrastructure as code (IaC) helps with availability, this solution does not meet the requirement of being always available. In addition, this solution offers no way to keep the database data after the database is recreated.
 
 For more information about CloudFormation, see What is AWS CloudFormation?
 
 
-D
-Deploy the application on Amazon EC2 instances in an Auto Scaling group behind an Application Load Balancer. Use Amazon RDS for MySQL for the database.
+D Deploy the application on Amazon EC2 instances in an Auto Scaling group behind an Application Load Balancer. Use Amazon RDS for MySQL for the database.
 
 Incorrect. With this solution, at least one instance and a database will run during the periods of inactivity. This solution does not minimize cost during the periods of inactivity. This solution is not the most cost-effective option.
 
@@ -2883,8 +2600,7 @@ What is the MOST cost-effective way to transfer this data?
 
 Report Content Errors
 
-A
-Export the data monthly from the existing S3 bucket to an AWS Snowball Edge Storage Optimized device. Ship the device to the on-premises location. Transfer the data. Return the device a week later.
+A Export the data monthly from the existing S3 bucket to an AWS Snowball Edge Storage Optimized device. Ship the device to the on-premises location. Transfer the data. Return the device a week later.
 
 Correct. The base price covers the device and 10 days of usage at the on-premises location. If the company returns the device within a week, the company pays the base price and the price for data transfer out of AWS.
 

--- a/pages/_notes/misc/Favicons.md
+++ b/pages/_notes/misc/Favicons.md
@@ -12,15 +12,10 @@ start at 512x512
 
 Define a color scheme from [here](https://meodai.github.io/poline/) 
 
-color palette: #3d7695, #2f5877, #a19587
-style: #3d7695, #2f5877, #a19587
+color palette: #3d7695, #2f5877, #a19587 style: #3d7695, #2f5877, #a19587
 
 
-bamr87: Based on the provided color scheme and theme of the desired image, generate a favicon image that is 512x512 pixels.
-color_scheme:
-  #3d7695
-  #2f5877
-  #a19587
+bamr87: Based on the provided color scheme and theme of the desired image, generate a favicon image that is 512x512 pixels. color_scheme: #3d7695 #2f5877 #a19587
 
 image_theme: "retro computers"
 

--- a/pages/_notes/misc/cloud.md
+++ b/pages/_notes/misc/cloud.md
@@ -662,8 +662,7 @@ For more information about QuickSight, see What Is Amazon QuickSight?
  
 ## 1.3 Prepare the application deployment package to be deployed to AWS.
 
-1/20
-0.0% complete
+1/20 0.0% complete
  
 A developer is preparing a deployment package for a Java implementation of an AWS Lambda function.
 
@@ -671,8 +670,7 @@ What should the developer include in the deployment package? (Select TWO.)
 
 Report Content Errors
 
-A
-Compiled application code
+A Compiled application code
 
 Correct. To create a Lambda function, you first create a Lambda function deployment package. This deployment package is a .zip or .jar file consisting of your code and any dependencies.
 
@@ -681,32 +679,28 @@ For more information about Lambda deployment packages, see Lambda deployment pac
 For more information about deploying a Lambda application, see Creating an application with continuous delivery in the Lambda console.
 
 
-B
-Java runtime environment
+B Java runtime environment
 
 Incorrect. Lambda provides Java runtime, so there is no need to include it in the deployment package.
 
 For more information about building Lambda functions with Java, see Building Lambda functions with Java.
 
 
-C
-References to the event sources
+C References to the event sources
 
 Incorrect. The event sources are external to Lambda and are used to invoke a Lambda function. As such, event sources are not part of a Lambda deployment package.
 
 For more information about event source mapping in Lambda, see AWS Lambda event source mappings.
 
 
-D
-Lambda execution role
+D Lambda execution role
 
 Incorrect. A Lambda execution role is an IAM role that grants the function permission to access AWS services and resources. This role is provided when a Lambda function is created. It is not included in the deployment package.
 
 For more information about Lambda execution roles, see AWS Lambda execution role.
 
 
-E
-Application dependencies
+E Application dependencies
 
 Correct. To create a Lambda function, you first create a Lambda function deployment package. This package is a .zip or .jar file consisting of your code and any dependencies.
 
@@ -724,12 +718,9 @@ AE
 
 
  
-1.3 Prepare the application deployment package to be deployed to AWS.
- This Question: 00:33
- Total: 01:31
+1.3 Prepare the application deployment package to be deployed to AWS. This Question: 00:33 Total: 01:31
 
-2/20
-5.0% complete
+2/20 5.0% complete
  
 A developer uses AWS CodeDeploy to deploy a Python application to a fleet of Amazon EC2 instances that run behind an Application Load Balancer. The instances run in an Amazon EC2 Auto Scaling group across multiple Availability Zones.
 
@@ -737,8 +728,7 @@ What should the developer include in the CodeDeploy deployment package?
 
 Report Content Errors
 
-A
-A launch template for the Amazon EC2 Auto Scaling group
+A A launch template for the Amazon EC2 Auto Scaling group
 
 Incorrect. A launch template for the Auto Scaling group is configured in Amazon EC2 AutoScaling. It is not configured in a CodeDeploy package.
 
@@ -747,16 +737,14 @@ For more information about Amazon EC2 Auto Scaling and how to configure it, see 
 For more information about Amazon EC2 Auto Scaling with a tutorial, see Getting started with Amazon EC2 Auto Scaling.
 
 
-B
-A CodeDeploy AppSpec file
+B A CodeDeploy AppSpec file
 
 Correct. The CodeDeploy AppSpec (application specific) file is unique to CodeDeploy. The AppSpec file is used to manage each deployment as a series of lifecycle event hooks, which are defined in the file.
 
 For more information about AppSpec files, see CodeDeploy application specification (AppSpec) files.
 
 
-C
-An EC2 role that grants the application access to AWS services
+C An EC2 role that grants the application access to AWS services
 
 Incorrect. An IAM policy by itself does not grant access to AWS services. The policy must be assigned to an IAM role. The role must be assigned to the instances to provide access.
 
@@ -765,8 +753,7 @@ For more information about IAM roles, see IAM roles.
 For more information about IAM roles on EC2 instances, see IAM roles for Amazon EC2.
 
 
-D
-An IAM policy that grants the application access to AWS services
+D An IAM policy that grants the application access to AWS services
 
 Incorrect. An IAM policy that grants access to AWS services is attached to IAM users, groups, or roles. You cannot attach an IAM policy to an application.
 
@@ -782,12 +769,9 @@ B
 
 
  
-1.4 Deploy serverless applications.
- This Question: 01:49
- Total: 03:20
+1.4 Deploy serverless applications. This Question: 01:49 Total: 03:20
 
-3/20
-10.0% complete
+3/20 10.0% complete
  
 A company is working on a project to enhance its serverless application development process. The company hosts applications on AWS Lambda. The development team regularly updates the Lambda code and wants to use stable code in production.
 
@@ -795,16 +779,14 @@ Which combination of steps should the development team take to configure Lambda 
 
 Report Content Errors
 
-A
-Create a new Lambda version every time a new code release needs testing.
+A Create a new Lambda version every time a new code release needs testing.
 
 Correct. Lambda function versions are designed to manage deployment of functions. They can be used for code changes, without affecting the stable production version of the code.
 
 For more information about Lambda function versions, see Lambda function versions.
 
 
-B
-Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready unqualified Amazon Resource Name (ARN) version. Point the Development alias to the $LATEST version.
+B Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready unqualified Amazon Resource Name (ARN) version. Point the Development alias to the $LATEST version.
 
 Correct. By creating separate aliases for Production and Development, systems can initiate the correct alias as needed. A Lambda function alias can be used to point to a specific Lambda function version. Using the functionality to update an alias and its linked version, the development team can update the required version as needed. The $LATEST version is the newest published version.
 
@@ -813,8 +795,7 @@ For more information about Lambda function aliases, see Lambda function aliases.
 For more information about Lambda function versions, see Lambda function versions.
 
 
-C
-Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to the production-ready qualified Amazon Resource Name (ARN) version. Point the Development alias to the variable LAMBDA_TASK_ROOT.
+C Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to the production-ready qualified Amazon Resource Name (ARN) version. Point the Development alias to the variable LAMBDA_TASK_ROOT.
 
 Incorrect. A Lambda function alias can only point to an unqualified function ARN. LAMBDA_TASK_ROOT is a variable used by Lambda to record the path to the code. However, it cannot be used in the way the response describes.
 
@@ -823,16 +804,14 @@ For more information about Lambda function versions, see Lambda function version
 For more information about Lambda variables, see Configuring environment variables.
 
 
-D
-Create a new Lambda layer every time a new code release needs testing.
+D Create a new Lambda layer every time a new code release needs testing.
 
 Incorrect. Using a Lambda layer, you can access additional code and content. It is not suitable for code updates.
 
 For more information about Lambda layers, see Creating and sharing Lambda layers.
 
 
-E
-Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready Lambda layer Amazon Resource Name (ARN). Point the Development alias to the $LATEST layer ARN.
+E Create two Lambda function aliases. Name one as Production and the other as Development. Point the Production alias to a production-ready Lambda layer Amazon Resource Name (ARN). Point the Development alias to the $LATEST layer ARN.
 
 Incorrect. Using a Lambda layer, you can access additional code and content. It is not suitable for code updates. Additionally, a Lambda function alias points to a Lambda function version.
 
@@ -850,12 +829,9 @@ AB
 
 
  
-1.4 Deploy serverless applications.
- This Question: 01:08
- Total: 04:29
+1.4 Deploy serverless applications. This Question: 01:08 Total: 04:29
 
-4/20
-15.0% complete
+4/20 15.0% complete
  
 Each time a developer publishes a new version of an AWS Lambda function, all the dependent event source mappings need to be updated with the reference to the new version’s Amazon Resource Name (ARN). These updates are time consuming and error-prone.
 
@@ -863,8 +839,7 @@ Which combination of actions should the developer take to avoid performing these
 
 Report Content Errors
 
-A
-Update event source mappings with the ARN of the Lambda layer.
+A Update event source mappings with the ARN of the Lambda layer.
 
 Incorrect. A Lambda event source mapping can either point to the version ARN, or an alias ARN, but not to the layer ARN.
 
@@ -875,32 +850,28 @@ For more information about creating and using Lambda function aliases, see Lambd
 For more information about Lambda layers, see Creating and sharing Lambda layers.
 
 
-B
-Point a Lambda alias to a new version of the Lambda function.
+B Point a Lambda alias to a new version of the Lambda function.
 
 Correct. A Lambda alias is a pointer to a specific Lambda function version.
 
 For more information about creating and using Lambda function aliases, see Lambda function aliases.
 
 
-C
-Create a Lambda alias for each published version of the Lambda function.
+C Create a Lambda alias for each published version of the Lambda function.
 
 Incorrect. This solution does not address your problem. Every alias has its own unique ARN. Therefore, you would still need to update the event source mapping with the new ARN when a new version is published.
 
 For more information about creating and using Lambda function aliases, see Lambda function aliases.
 
 
-D
-Point a Lambda alias to a new Lambda function alias.
+D Point a Lambda alias to a new Lambda function alias.
 
 Incorrect. A Lambda alias cannot point to another Lambda alias, only to a Lambda function version.
 
 For more information about Lambda function aliases, including their creation and management, see Using aliases.
 
 
-E
-Update the event source mappings with the Lambda alias ARN.
+E Update the event source mappings with the Lambda alias ARN.
 
 Correct. Instead of using ARNs for the Lambda function in event source mappings, you can use an alias ARN. You do not need to update your event source mappings when you promote a new version or roll back to a previous version.
 
@@ -916,12 +887,9 @@ BE
 
 
  
-2.1 Make authenticated calls to AWS services.
- This Question: 00:23
- Total: 04:53
+2.1 Make authenticated calls to AWS services. This Question: 00:23 Total: 04:53
 
-5/20
-20.0% complete
+5/20 20.0% complete
  
 An application that runs on Amazon EC2 instances needs credentials to make an API call to Amazon DynamoDB.
 
@@ -929,32 +897,28 @@ What is the MOST secure method to provide credentials to perform the call?
 
 Report Content Errors
 
-A
-Create a user and a password with the needed permissions. Store the credentials in a configuration file on the EC2 instances.
+A Create a user and a password with the needed permissions. Store the credentials in a configuration file on the EC2 instances.
 
 Incorrect. You could store AWS credentials directly within the EC2 instances and allow applications that run on those instances to use those credentials. However, you would have to manage the credentials. You would have to securely pass the credentials to each instance and update each instance when it is time to rotate the credentials. This approach is not the most secure solution.
 
 For more information about using an IAM role to grant permissions to applications running on EC2 instances, see Use roles for applications that run on Amazon EC2 instances. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-roles-with-ec2
 
 
-B
-Assign an IAM role with the correct permissions to the DynamoDB table.
+B Assign an IAM role with the correct permissions to the DynamoDB table.
 
 Incorrect. While roles are the most secure way to provide these credentials, it is the EC2 instance that is making the API call. The instances, not the DynamoDB table, need to be assigned the proper credentials.
 
 For more information about using an IAM role to grant permissions to applications running on EC2 instances, see Use roles for applications that run on Amazon EC2 instances. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-roles-with-ec2
 
 
-C
-Assign an IAM role with the correct permissions to the EC2 instances.
+C Assign an IAM role with the correct permissions to the EC2 instances.
 
 Correct. The most secure method is to create an IAM role with the appropriate policy. Attach that IAM role to the EC2 instance that is making the API call. Long-term credentials are not stored, which reduces risk of compromising the credentials.
 
 For more information about using an IAM role to grant permissions to applications running on EC2 instances, see Use roles for applications that run on Amazon EC2 instances.
 
 
-D
-Add the name of an IAM policy with the correct permissions to a configuration file on the instances.
+D Add the name of an IAM policy with the correct permissions to a configuration file on the instances.
 
 Incorrect. IAM policies are associated with IAM identities (users, groups, or roles) or AWS resources. A configuration file of instances is not an IAM identity or an AWS resource. Therefore, an IAM policy cannot be associated with it.
 
@@ -970,12 +934,9 @@ C
 
 
  
-2.2 Implement encryption using AWS services.
- This Question: 01:17
- Total: 06:10
+2.2 Implement encryption using AWS services. This Question: 01:17 Total: 06:10
 
-6/20
-25.0% complete
+6/20 25.0% complete
  
 A company wants to store sensitive user data in Amazon S3 and encrypt this data at rest. The company must manage the encryption keys and use Amazon S3 to perform the encryption.
 
@@ -983,30 +944,26 @@ How can a developer meet these requirements?
 
 Report Content Errors
 
-A
-Enable default encryption for the S3 bucket by using the option for server-side encryption with customer-provided encryption keys (SSE-C).
+A Enable default encryption for the S3 bucket by using the option for server-side encryption with customer-provided encryption keys (SSE-C).
 
 Incorrect. The default encryption behavior for an S3 bucket can be configured to either SSE-S3 or customer master keys (CMKs) stored in AWS Key Management Service (AWS KMS) (SSE-KMS). Although you can upload files with SSE-C, you cannot set it as a default S3 bucket encryption.
 
 For more information about S3 encryption, see Setting default server-side encryption behavior for Amazon S3 buckets.
 
 
-B
-Enable client-side encryption with an encryption key. Upload the encrypted object to the S3 bucket.
+B Enable client-side encryption with an encryption key. Upload the encrypted object to the S3 bucket.
 
 Incorrect. Client-side encryption involves encrypting data before sending it to Amazon S3. This solution does not meet the requirement for Amazon to provide the encryption.
 
 For more information about client-side encryption for S3 buckets, see Protecting data using client-side encryption.
 
 
-C
-Enable server-side encryption with Amazon S3 managed encryption keys (SSE-S3). Upload an object to the S3 bucket.
+C Enable server-side encryption with Amazon S3 managed encryption keys (SSE-S3). Upload an object to the S3 bucket.
 
 Incorrect. SSE-S3 uses an encryption key provided by Amazon S3 to encrypt data. This solution does not meet the requirement for the company to manage the encryption keys.
 
 
-D
-Enable server-side encryption with customer-provided encryption keys (SSE-C). Upload an object to the S3 bucket.
+D Enable server-side encryption with customer-provided encryption keys (SSE-C). Upload an object to the S3 bucket.
 
 Correct. When you upload an object, Amazon S3 uses the encryption key you provide to apply AES-256 encryption to your data and removes the encryption key from memory.
 
@@ -1022,12 +979,9 @@ D
 
 
  
-2.2 Implement encryption using AWS services.
- This Question: 01:29
- Total: 07:40
+2.2 Implement encryption using AWS services. This Question: 01:29 Total: 07:40
 
-7/20
-30.0% complete
+7/20 30.0% complete
  
 A company is developing a Python application that submits data to an Amazon DynamoDB table. The company requires client-side encryption of specific data items and end-to-end protection for the encrypted data in transit and at rest.
 
@@ -1035,8 +989,7 @@ Which combination of steps will meet the requirement for the encryption of speci
 
 Report Content Errors
 
-A
-Generate symmetric encryption keys with AWS Key Management Service (AWS KMS).
+A Generate symmetric encryption keys with AWS Key Management Service (AWS KMS).
 
 Correct. When the DynamoDB Encryption Client is configured to use AWS KMS, it uses a customer master key (CMK) that is always encrypted when used outside of AWS KMS. This cryptographic materials provider returns a unique encryption key and signing key for every table item. This method of encryption uses a symmetric CMK.
 
@@ -1045,8 +998,7 @@ For more information about the Direct KMS Materials Provider used by the DynamoD
 For more information about CMKs, see AWS Key Management Service concepts.
 
 
-B
-Generate asymmetric encryption keys with AWS Key Management Service (AWS KMS).
+B Generate asymmetric encryption keys with AWS Key Management Service (AWS KMS).
 
 Incorrect. When the DynamoDB Encryption Client is configured to use AWS KMS, it uses a customer master key (CMK) that is always encrypted when used outside of AWS KMS. This cryptographic materials provider returns a unique encryption key and signing key for every table item. This method of encryption would require a symmetric CMK, not an asymmetric key.
 
@@ -1055,8 +1007,7 @@ For more information about the Direct KMS Materials Provider, see Direct KMS Mat
 For more information about CMKs, see AWS Key Management Service concepts.
 
 
-C
-Use generated keys with the DynamoDB Encryption Client.
+C Use generated keys with the DynamoDB Encryption Client.
 
 Correct. The DynamoDB Encryption Client provides end-to-end protection for your data in transit and at rest. You can encrypt selected items or attribute values in a table.
 
@@ -1067,8 +1018,7 @@ For more information about the DynamoDB Encryption Client, see What is the Amazo
 For more information about DynamoDB Encryption Client, see How the DynamoDB Encryption Client works.
 
 
-D
-Use generated keys to configure DynamoDB table encryption with AWS managed customer master keys (CMKs).
+D Use generated keys to configure DynamoDB table encryption with AWS managed customer master keys (CMKs).
 
 Incorrect. This method is used for server-side encryption at rest. This solution does not meet the requirement for client-side encryption.
 
@@ -1077,8 +1027,7 @@ For more information about DynamoDB client-side and server-side encryption, see 
 For more information about DynamoDB encryption at rest, see DynamoDB Encryption at Rest.
 
 
-E
-Use generated keys to configure DynamoDB table encryption with AWS owned customer master keys (CMKs).
+E Use generated keys to configure DynamoDB table encryption with AWS owned customer master keys (CMKs).
 
 Incorrect. This method is used for server-side encryption at rest. This solution does not meet the requirement for client-side encryption.
 
@@ -1096,12 +1045,9 @@ AC
 
 
  
-2.3 Implement application authentication and authorization.
- This Question: 02:14
- Total: 09:54
+2.3 Implement application authentication and authorization. This Question: 02:14 Total: 09:54
 
-8/20
-35.0% complete
+8/20 35.0% complete
  
 A company is developing a REST API with Amazon API Gateway. Access to the API should be limited to users in the existing Amazon Cognito user pool.
 
@@ -1109,16 +1055,14 @@ Which combination of steps should a developer perform to secure the API? (Select
 
 Report Content Errors
 
-A
-Create an AWS Lambda authorizer for the API.
+A Create an AWS Lambda authorizer for the API.
 
 Incorrect. A Lambda authorizer is an API Gateway feature that uses a Lambda function to implement a custom authorization scheme to control access to your API. This solution works if the users are authenticated with OAuth or SAML. However, a Lambda authorizer does not fit this scenario.
 
 For more information about using the Lambda authorizer, see Use API Gateway Lambda authorizers.
 
 
-B
-Create an Amazon Cognito authorizer for the API.
+B Create an Amazon Cognito authorizer for the API.
 
 Correct. An Amazon Cognito authorizer should be used for integration with Amazon Cognito user pools.
 
@@ -1127,16 +1071,14 @@ For more information about how to control access to a REST API by using Amazon C
 For more information about how to integrate a REST API with an Amazon Cognito user pool, see Integrate a REST API with an Amazon Cognito user pool.
 
 
-C
-Configure the authorizer for the API resource.
+C Configure the authorizer for the API resource.
 
 Incorrect. The authorizer cannot be configured for the API resource.
 
 For more information about how to control access to a REST API by using Amazon Cognito user pools, see Control access to a REST API using Amazon Cognito user pools as authorizer.
 
 
-D
-Configure the API methods to use the authorizer.
+D Configure the API methods to use the authorizer.
 
 Correct. In addition to creating an authorizer, you are required to configure an API method to use that authorizer for the API.
 
@@ -1145,8 +1087,7 @@ For more information about how to configure the API methods to use the authorize
 For more information about how to integrate a REST API with an Amazon Cognito user pool, see Integrate a REST API with an Amazon Cognito user pool.
 
 
-E
-Configure the authorizer for the API stage.
+E Configure the authorizer for the API stage.
 
 Incorrect. The authorizer cannot be configured in the API stage.
 
@@ -1161,12 +1102,9 @@ BD
 
 
  
-2.3 Implement application authentication and authorization.
- This Question: 01:12
- Total: 11:07
+2.3 Implement application authentication and authorization. This Question: 01:12 Total: 11:07
 
-9/20
-40.0% complete
+9/20 40.0% complete
  
 A developer is implementing a mobile app to provide personalized services to app users. The application code makes calls to Amazon S3 and Amazon Simple Queue Service (Amazon SQS).
 
@@ -1174,40 +1112,35 @@ Which options can the developer use to authenticate the app users? (Select TWO.)
 
 Report Content Errors
 
-A
-Authenticate to the Amazon Cognito identity pool directly.
+A Authenticate to the Amazon Cognito identity pool directly.
 
 Incorrect. The Amazon Cognito identity pool does not provide the application with user authentication service. Your application can use identity pools to exchange user pool tokens for AWS credentials.
 
 For more information about Amazon Cognito, see What Is Amazon Cognito?
 
 
-B
-Authenticate to AWS Identity and Access Management (IAM) directly.
+B Authenticate to AWS Identity and Access Management (IAM) directly.
 
 Incorrect. IAM does not provide the application with direct user authentication service. You use IAM users to control access to AWS.
 
 For more information about IAM users, see IAM users.
 
 
-C
-Authenticate to the Amazon Cognito user pool directly.
+C Authenticate to the Amazon Cognito user pool directly.
 
 Correct. The Amazon Cognito user pool provides direct user authentication.
 
 For more information about Amazon Cognito user pools, see Adding User Pool Sign-in Through a Third Party.
 
 
-D
-Federate authentication by using Login with Amazon with the users managed with AWS Security Token Service (AWS STS).
+D Federate authentication by using Login with Amazon with the users managed with AWS Security Token Service (AWS STS).
 
 Incorrect. AWS STS does not provide the application with user authentication service. It is used to request temporary credentials for IAM users. All the users would have to have IAM users, and that would be cumbersome to manage.
 
 For more information about AWS STS, see Welcome to the AWS Security Token Service API Reference.
 
 
-E
-Federate authentication by using Login with Amazon with the users managed with the Amazon Cognito user pool.
+E Federate authentication by using Login with Amazon with the users managed with the Amazon Cognito user pool.
 
 Correct. The Amazon Cognito user pool provides a federated authentication option with third-party identity provider (IdP), including amazon.com.
 
@@ -1222,12 +1155,9 @@ CE
 
 
  
-3.1 Write code for serverless applications.
- This Question: 01:15
- Total: 12:22
+3.1 Write code for serverless applications. This Question: 01:15 Total: 12:22
 
-10/20
-45.0% complete
+10/20 45.0% complete
  
 A company is implementing several order processing workflows. Each workflow is implemented by using AWS Lambda functions for each task.
 
@@ -1235,8 +1165,7 @@ Which combination of steps should a developer follow to implement these workflow
 
 Report Content Errors
 
-A
-Define a AWS Step Functions task for each Lambda function.
+A Define a AWS Step Functions task for each Lambda function.
 
 Correct. Step Functions is based on state machines and tasks. A state machine is a workflow. Tasks perform work by coordinating with other AWS services, such as Lambda.
 
@@ -1245,16 +1174,14 @@ For more information about Step Functions tasks, see Task.
 For more information about Step Functions, see Getting Started with AWS Step Functions.
 
 
-B
-Define a AWS Step Functions task for each workflow.
+B Define a AWS Step Functions task for each workflow.
 
 Incorrect. A Step Functions workflow is implemented with one or more tasks.
 
 For more information about Step Functions tasks, see Task.
 
 
-C
-Write code that polls the AWS Step Functions invocation to coordinate each workflow.
+C Write code that polls the AWS Step Functions invocation to coordinate each workflow.
 
 Incorrect. You do not need to poll the Step Functions invocation to coordinate the workflow. State machines are precisely designed to coordinate the workflow.
 
@@ -1263,8 +1190,7 @@ For more information about Step Functions tasks, see Task.
 For more information about Step Functions, see Getting Started with AWS Step Functions.
 
 
-D
-Define an AWS Step Functions state machine for each workflow.
+D Define an AWS Step Functions state machine for each workflow.
 
 Correct. A state machine is a workflow. It can be used to express a workflow as a number of states, their relationships, and their input and output. You can coordinate individual tasks with Step Functions by expressing your workflow as a finite state machine, written in the Amazon States Language.
 
@@ -1273,8 +1199,7 @@ For more information about the Standard and Express workflows of Step Functions,
 For more information about states of Step Functions, see States.
 
 
-E
-Define an AWS Step Functions state machine for each Lambda function.
+E Define an AWS Step Functions state machine for each Lambda function.
 
 Incorrect. A Step Functions state machine represents a workflow and not a Lambda function. A Lambda function would be represented as a task.
 
@@ -1289,12 +1214,9 @@ AD
 
 
  
-3.2 Translate functional requirements into application design.
- This Question: 01:08
- Total: 13:26
+3.2 Translate functional requirements into application design. This Question: 01:08 Total: 13:26
 
-11/20
-50.0% complete
+11/20 50.0% complete
  
 A company is migrating a web service to the AWS Cloud. The web service accepts requests by using HTTP (port 80). The company wants to use an AWS Lambda function to process HTTP requests.
 
@@ -1302,32 +1224,28 @@ Which application design will satisfy these requirements?
 
 Report Content Errors
 
-A
-Create an Amazon API Gateway API. Configure proxy integration with the Lambda function.
+A Create an Amazon API Gateway API. Configure proxy integration with the Lambda function.
 
 Incorrect. API Gateway does not support unencrypted (HTTP) endpoints. HTTP is required in this scenario.
 
 For more information about API Gateway endpoint protocols, see Amazon API Gateway FAQs (Q: Can I create HTTPS endpoints?)
 
 
-B
-Create an Amazon API Gateway API. Configure non-proxy integration with the Lambda function.
+B Create an Amazon API Gateway API. Configure non-proxy integration with the Lambda function.
 
 Incorrect. API Gateway does not support unencrypted (HTTP) endpoints. HTTP is required in this scenario.
 
 For more information about API Gateway endpoint protocols, see Amazon API Gateway FAQs (Q: Can I create HTTPS endpoints?)
 
 
-C
-Configure the Lambda function to listen to inbound network connections on port 80.
+C Configure the Lambda function to listen to inbound network connections on port 80.
 
 Incorrect. Lambda blocks inbound network connections. Although you cannot directly invoke a Lambda function, other supported services can invoke a function.
 
 For more information about using Lambda with other services, see Using AWS Lambda with other services.
 
 
-D
-Configure the Lambda function as a target in the Application Load Balancer target group.
+D Configure the Lambda function as a target in the Application Load Balancer target group.
 
 Correct. Elastic Load Balancing supports Lambda functions as a target for an Application Load Balancer. You can use load balancer rules to route HTTP requests to a function, based on the path or the header values. Then, process the request and return an HTTP response from your Lambda function.
 
@@ -1343,12 +1261,9 @@ D
 
 
  
-3.2 Translate functional requirements into application design.
- This Question: 01:00
- Total: 14:27
+3.2 Translate functional requirements into application design. This Question: 01:00 Total: 14:27
 
-12/20
-55.0% complete
+12/20 55.0% complete
  
 A company is developing an image processing application. When an image is uploaded to an Amazon S3 bucket, a number of independent and separate services must be invoked to process the image. The services do not have to be available immediately, but they must process every image.
 
@@ -1356,32 +1271,28 @@ Which application design satisfies these requirements?
 
 Report Content Errors
 
-A
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Each service pulls the message from the same queue.
+A Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Each service pulls the message from the same queue.
 
 Incorrect. After a consumer retrieves and processes a message from a queue, it deletes the message in the queue. The result is that only one service receives the message.
 
 For more information about Amazon SQS architecture, see Basic Amazon SQS architecture.
 
 
-B
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Each service subscribes to the same topic.
+B Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Each service subscribes to the same topic.
 
 Incorrect. An Amazon SQS delivery policy defines how Amazon SNS retries the delivery of messages when a delivery error occurs. Amazon SNS stops retrying the delivery and discards the message when a delivery policy is exhausted. If one of the services is temporarily unavailable, it would not receive the message.
 
 For more information about Amazon SNS message delivery retries, see Amazon SNS message delivery retries.
 
 
-C
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Subscribe a separate Amazon Simple Notification Service (Amazon SNS) topic for each service to an Amazon SQS queue.
+C Configure an Amazon S3 event notification that publishes to an Amazon Simple Queue Service (Amazon SQS) queue. Subscribe a separate Amazon Simple Notification Service (Amazon SNS) topic for each service to an Amazon SQS queue.
 
 Incorrect. An Amazon SQS queue is not a supported event source for Amazon SNS.
 
 For more information about Amazon SNS event sources, see Amazon SNS event sources.
 
 
-D
-Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe a separate Simple Queue Service (Amazon SQS) queue for each service to the Amazon SNS topic.
+D Configure an Amazon S3 event notification that publishes to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe a separate Simple Queue Service (Amazon SQS) queue for each service to the Amazon SNS topic.
 
 Correct. Each service can subscribe to an individual Amazon SQS queue, which receives an event notification from the Amazon SNS topic. This is a fanout architectural implementation.
 
@@ -1396,12 +1307,9 @@ D
 
 
  
-3.3 Implement application design into application code.
- This Question: 00:53
- Total: 15:20
+3.3 Implement application design into application code. This Question: 00:53 Total: 15:20
 
-13/20
-60.0% complete
+13/20 60.0% complete
  
 A developer wants to implement Amazon EC2 Auto Scaling for a Multi-AZ web application. However, the developer is concerned that user sessions will be lost during scale-in events.
 
@@ -1409,24 +1317,21 @@ How can the developer store the session state and share it across the EC2 instan
 
 Report Content Errors
 
-A
-Write the sessions to an Amazon Kinesis data stream. Configure the application to poll the stream.
+A Write the sessions to an Amazon Kinesis data stream. Configure the application to poll the stream.
 
 Incorrect. A Kinesis data stream is used for data ingestion and for processing of data records. However, it does not have the features needed for this use case. ElastiCache is better suited for this requirement.
 
 For more information about Kinesis, see Getting started with Amazon Kinesis Data Streams.
 
 
-B
-Publish the sessions to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe each instance in the group to the topic.
+B Publish the sessions to an Amazon Simple Notification Service (Amazon SNS) topic. Subscribe each instance in the group to the topic.
 
 Incorrect. Amazon SNS is used for publish-subscribe messaging. Messages are delivered as soon as they are sent. Amazon SNS is not designed to store persistent session data.
 
 For more information about SNS, see Amazon SNS FAQs.
 
 
-C
-Store the sessions in an Amazon ElastiCache for Memcached cluster. Configure the application to use the Memcached API.
+C Store the sessions in an Amazon ElastiCache for Memcached cluster. Configure the application to use the Memcached API.
 
 Correct. ElastiCache for Memcached is a distributed in-memory data store or cache environment in the cloud. It will meet the developer's requirement of persistent storage and is fast to access.
 
@@ -1435,8 +1340,7 @@ For more information about ElastiCache, see What is Amazon ElastiCache for Memca
 For more information about Memcached, see Amazon ElastiCache for Memcached.
 
 
-D
-Write the sessions to an Amazon Elastic Block Store (Amazon EBS) volume. Mount the volume to each instance in the group.
+D Write the sessions to an Amazon Elastic Block Store (Amazon EBS) volume. Mount the volume to each instance in the group.
 
 Incorrect. This solution would not synchronize the session data across all instances. Amazon EBS volumes are instance specific.
 
@@ -1449,12 +1353,9 @@ C
 
 
  
-3.3 Implement application design into application code.
- This Question: 00:44
- Total: 16:04
+3.3 Implement application design into application code. This Question: 00:44 Total: 16:04
 
-14/20
-65.0% complete
+14/20 65.0% complete
  
 A developer is writing a component that will read customer orders from an Amazon Simple Queue Service (Amazon SQS) queue and process them. The developer wants to reduce empty responses to the ReceiveMessage call and obtain a customer order message as soon as it is available.
 
@@ -1462,16 +1363,14 @@ What should the developer do when writing code to retrieve messages from the que
 
 Report Content Errors
 
-A
-Use SQS short polling.
+A Use SQS short polling.
 
 Incorrect. SQS short polling queries only a random subset of the servers for messages. To retrieve all messages, you might need multiple short queries. If the selected servers do not contain any messages, then empty responses would be sent. Additionally, short polling sends a response right away. These factors could result in empty responses.
 
 For more information about SQS queries, see Amazon SQS short and long polling.
 
 
-B
-Use SQS long polling.
+B Use SQS long polling.
 
 Correct. SQS long polling queries all servers for messages and sends a response after it collects at least one available message. Additionally, long polling would send an empty response only if the queue is empty and the polling wait time expires.
 
@@ -1480,16 +1379,14 @@ For more information about SQS queries, see Amazon SQS short and long polling.
 For more information about the ReceiveMessage API call, see ReceiveMessage.
 
 
-C
-Extend the visibility timeout.
+C Extend the visibility timeout.
 
 Incorrect. When a consumer receives and processes a message from an SQS queue, the message remains in the queue until the consumer deletes the message from the queue. To avoid other consumers from processing the same message, you can specify a visibility timeout value. A visibility timeout value is a period of time during which SQS prevents other consumers from receiving and processing the message.
 
 For more information about visibility timeouts for Amazon SQS, see Amazon SQS visibility timeout.
 
 
-D
-Increase the maximum number of messages to return.
+D Increase the maximum number of messages to return.
 
 Incorrect. Although a single ReceiveMessage response can include multiple messages, an increase in the MaxNumberOfMessages parameter will not ensure that all servers are queried for messages.
 
@@ -1504,12 +1401,9 @@ B
 
 
  
-3.4 Write code that interacts with AWS services by using APIs, SDKs, and AWS CLI.
- This Question: 01:17
- Total: 17:22
+3.4 Write code that interacts with AWS services by using APIs, SDKs, and AWS CLI. This Question: 01:17 Total: 17:22
 
-15/20
-70.0% complete
+15/20 70.0% complete
  
 A developer is integrating a legacy web application that runs on a fleet of Amazon EC2 instances with an Amazon DynamoDB table. There is no AWS SDK for the programming language that was used to implement the web application.
 
@@ -1517,38 +1411,33 @@ Which combination of steps should the developer perform to make an API call to A
 
 Report Content Errors
 
-A
-Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include an XML document that contains the request attributes.
+A Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include an XML document that contains the request attributes.
 
 Incorrect. The XML data format is not used for HTTPS-based low-level API calls.
 
 For more information about API calls to DynamoDB, see DynamoDB Low-Level API.
 
 
-B
-Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include a JSON document that contains the request attributes.
+B Make an HTTPS POST request to the DynamoDB API endpoint for the AWS Region. In the request body, include a JSON document that contains the request attributes.
 
 Correct. The HTTPS-based low-level AWS API for DynamoDB uses JSON as a wire protocol format.
 
 For more information about API calls to DynamoDB, see DynamoDB Low-Level API.
 
 
-C
-Sign the requests by using AWS access keys and Signature Version 4.
+C Sign the requests by using AWS access keys and Signature Version 4.
 
 Correct. When you send HTTP requests to AWS, you sign the requests so that AWS can identify who sent them. Requests are signed with your AWS access key, which consists of an access key ID and secret access key. AWS supports two signature versions: Signature Version 4 and Signature Version 2. AWS recommends the use of Signature Version 4.
 
 For more information about signing AWS API requests, see Signing AWS API requests.
 
 
-D
-Use an EC2 SSH key to calculate Signature Version 4 of the request.
+D Use an EC2 SSH key to calculate Signature Version 4 of the request.
 
 Incorrect. An SSH key cannot be used to calculate Signature Version 4 of the low-level API request.
 
 
-E
-Provide the signature value through the HTTP X-API-Key header.
+E Provide the signature value through the HTTP X-API-Key header.
 
 Incorrect. The proper HTTP header for the signature value in low-level API calls is Authorization.
 
@@ -1564,12 +1453,9 @@ BC
 
 
  
-4.1 Optimize applications to best use AWS services and features
- This Question: 03:14
- Total: 20:36
+4.1 Optimize applications to best use AWS services and features This Question: 03:14 Total: 20:36
 
-16/20
-75.0% complete
+16/20 75.0% complete
  
 A developer has written several custom applications that read and write to the same Amazon DynamoDB table. Each time the data in the DynamoDB table is modified, this change should be sent to an external API.
 
@@ -1577,32 +1463,28 @@ Which combination of steps should the developer perform to accomplish this task?
 
 Report Content Errors
 
-A
-Configure an AWS Lambda function to poll the stream and call the external API.
+A Configure an AWS Lambda function to poll the stream and call the external API.
 
 Correct. If you enable DynamoDB Streams on a table, you can associate the stream Amazon Resource Name (ARN) with an Lambda function that you write. Immediately after an item in the table is modified, a new record appears in the table's stream. Lambda polls the stream and invokes your Lambda function synchronously when it detects new stream records.
 
 For more information about how to use DynamoDB Streams to create an event that invokes a Lambda function, see Tutorial: Process New Items with DynamoDB Streams and Lambda.
 
 
-B
-Configure an event in Amazon EventBridge (Amazon CloudWatch Events) that publishes the change to an Amazon Managed Streaming for Apache Kafka (Amazon MSK) data stream.
+B Configure an event in Amazon EventBridge (Amazon CloudWatch Events) that publishes the change to an Amazon Managed Streaming for Apache Kafka (Amazon MSK) data stream.
 
 Incorrect. EventBridge (CloudWatch Events) is used to connect applications with a variety of data. It would not be able to detect updates to a DynamoDB table.
 
 For more information about EventBridge (CloudWatch Events), see What Is Amazon EventBridge?
 
 
-C
-Create a trigger in the DynamoDB table to publish the change to an Amazon Kinesis data stream.
+C Create a trigger in the DynamoDB table to publish the change to an Amazon Kinesis data stream.
 
 Incorrect. A trigger cannot be enabled on a DynamoDB table. To create a trigger, a DynamoDB stream should be enabled on the specific DynamoDB table.
 
 For more information about how to use DynamoDB Streams to create an event that invokes an AWS Lambda function, see DynamoDB Streams and AWS Lambda Triggers.
 
 
-D
-Deliver the stream to an Amazon Simple Notification Service (Amazon SNS) topic and subscribe the API to the topic.
+D Deliver the stream to an Amazon Simple Notification Service (Amazon SNS) topic and subscribe the API to the topic.
 
 Incorrect. A DynamoDB stream cannot be used to create an Amazon SNS topic.
 
@@ -1613,8 +1495,7 @@ For more information about how Amazon SNS works, see What is Amazon SNS?
 For more information about how to create a topic in Amazon SNS, see Creating an Amazon SNS topic.
 
 
-E
-Enable DynamoDB Streams on the table.
+E Enable DynamoDB Streams on the table.
 
 Correct. You can enable DynamoDB Streams on a table to create an event that invokes an AWS Lambda function.
 
@@ -1629,12 +1510,9 @@ AE
 
 
  
-4.2 Migrate existing application code to run on AWS.
- This Question: 01:13
- Total: 21:50
+4.2 Migrate existing application code to run on AWS. This Question: 01:13 Total: 21:50
 
-17/20
-80.0% complete
+17/20 80.0% complete
  
 A company is migrating the create, read, update, and delete (CRUD) functionality of an existing Java web application to AWS Lambda.
 
@@ -1642,8 +1520,7 @@ Which minimal code refactoring is necessary for the CRUD operations to run in th
 
 Report Content Errors
 
-A
-Implement a Lambda handler function.
+A Implement a Lambda handler function.
 
 Correct. Every Lambda function needs a Lambda-specific handler. Specifics of authoring vary between runtimes, but all runtimes share a common programming model that defines the interface between your code and the runtime code. You tell the runtime which method to run by defining a handler in the function configuration. The runtime runs that method. Next, the runtime passes in objects to the handler that contain the invocation event and context, such as the function name and request ID.
 
@@ -1654,24 +1531,21 @@ For more information about Lambda features, see Lambda features.
 For more information about the Lambda handler function in Java, see AWS Lambda function handler in Java.
 
 
-B
-Import an AWS X-Ray package.
+B Import an AWS X-Ray package.
 
 Incorrect. Lambda is already integrated with X-Ray. Importing X-Ray is only needed for full instrumentation, which is optional and not part of the access control that is required by the scenario.
 
 For more information about X-Ray, see What is AWS X-Ray?
 
 
-C
-Rewrite the application code in Python.
+C Rewrite the application code in Python.
 
 Incorrect. Lambda supports Java, so you would not rewrite the code in Python. This solution would not meet the requirements of the question.
 
 For more information about the languages that Lambda supports, see AWS Lambda FAQs.
 
 
-D
-Add a reference to the Lambda execution role.
+D Add a reference to the Lambda execution role.
 
 Incorrect. The Lambda execution role is an IAM role that grants the function permission to access AWS services and resources. The Lambda execution role exists outside the application code, so it cannot be changed by refactoring the application code.
 
@@ -1686,12 +1560,9 @@ A
 
 
  
-5.1 Write code that can be monitored.
- This Question: 00:36
- Total: 22:26
+5.1 Write code that can be monitored. This Question: 00:36 Total: 22:26
 
-18/20
-85.0% complete
+18/20 85.0% complete
  
 A company plans to use AWS log monitoring services to monitor an application that runs on premises. Currently, the application runs on a recent version of Ubuntu Server and outputs the logs to a local file.
 
@@ -1699,40 +1570,35 @@ Which combination of steps should a developer perform to accomplish this goal? (
 
 Report Content Errors
 
-A
-Update the application code to include calls to the agent API for log collection.
+A Update the application code to include calls to the agent API for log collection.
 
 Incorrect. No update to the application code is necessary. The unified CloudWatch agent can be configured to read the local file for the log entries.
 
 For more information about collecting metrics and logs for on-premises servers with the CloudWatch agent, see Collecting metrics and logs from Amazon EC2 instances and on-premises servers with the CloudWatch agent.
 
 
-B
-Install the Amazon Elastic Container Service (Amazon ECS) container agent on the server.
+B Install the Amazon Elastic Container Service (Amazon ECS) container agent on the server.
 
 Incorrect. The ECS container agent allows container instances to connect to your cluster. You do not use it for monitoring the performance of the application code.
 
 For more information about the ECS container agent, see Amazon ECS container agent.
 
 
-C
-Install the unified Amazon CloudWatch agent on the server.
+C Install the unified Amazon CloudWatch agent on the server.
 
 Correct. The unified CloudWatch agent needs to be installed on the server. Ubuntu Server 18.04 is one of the many supported operating systems.
 
 For more information about collecting metrics and logs for on-premises servers with CloudWatch agent, see Collecting metrics and logs from Amazon EC2 instances and on-premises servers with the CloudWatch agent.
 
 
-D
-Configure the long-term AWS credentials on the server to enable log collection by the agent.
+D Configure the long-term AWS credentials on the server to enable log collection by the agent.
 
 Correct. When you install the unified CloudWatch agent on an on-premises server, you will specify a named profile that contains the credentials of the IAM user.
 
 For more information about collecting metrics and logs for on-premises servers with CloudWatch agent, see Collecting metrics and logs from Amazon EC2 instances and on-premises servers with the CloudWatch agent.
 
 
-E
-Attach an IAM role to the server to enable log collection by the agent.
+E Attach an IAM role to the server to enable log collection by the agent.
 
 Incorrect. You cannot attach an IAM role to an on-premises server. An IAM user, not an IAM role, provides credentials for an on-premises server. An IAM role provides server credentials for Amazon EC2 instances.
 
@@ -1747,12 +1613,9 @@ CD
 
 
  
-5.1 Write code that can be monitored.
- This Question: 01:13
- Total: 23:40
+5.1 Write code that can be monitored. This Question: 01:13 Total: 23:40
 
-19/20
-90.0% complete
+19/20 90.0% complete
  
 A developer wants to monitor invocations of an AWS Lambda function by using Amazon CloudWatch Logs. The developer added a number of print statements to the function code that write the logging information to the stdout stream. After running the function, the developer does not see any log data being generated.
 
@@ -1760,32 +1623,28 @@ Why does the log data NOT appear in the CloudWatch logs?
 
 Report Content Errors
 
-A
-The log data is not written to the stderr stream.
+A The log data is not written to the stderr stream.
 
 Incorrect. To output logs from your function code, you can use the print method or any logging library that writes to stdout or stderr.
 
 For more information about Lambda function logging, see AWS Lambda function logging in Python.
 
 
-B
-Lambda function logging is not automatically enabled.
+B Lambda function logging is not automatically enabled.
 
 Incorrect. Lambda automatically monitors Lambda functions and reports metrics through CloudWatch. Lambda automatically tracks the number of requests, the invocation duration per request, and the number of requests that result in an error.
 
 For more information about troubleshooting Lambda applications, see Monitoring and troubleshooting Lambda applications.
 
 
-C
-The execution role for the Lambda function did not grant permissions to write log data to CloudWatch Logs.
+C The execution role for the Lambda function did not grant permissions to write log data to CloudWatch Logs.
 
 Correct. The function needs permission to call CloudWatch Logs. Update the execution role to grant the permission. You can use the managed policy of AWSLambdaBasicExecutionRole.
 
 For more information about troubleshooting execution issues in Lambda, see Troubleshoot execution issues in Lambda.
 
 
-D
-The Lambda function outputs the logs to an Amazon S3 bucket.
+D The Lambda function outputs the logs to an Amazon S3 bucket.
 
 Incorrect. Lambda automatically stores logs generated by your code through CloudWatch Logs. You can view logs for Lambda functions by using the Lambda console, the CloudWatch console, the AWS CLI, or the CloudWatch API. You can transfer the logs from this CloudWatch log to an S3 bucket.
 
@@ -1802,12 +1661,9 @@ C
 
 
  
-5.2 Perform root cause analysis on faults found in testing or production.
- This Question: 00:29
- Total: 24:10
+5.2 Perform root cause analysis on faults found in testing or production. This Question: 00:29 Total: 24:10
 
-20/20
-95.0% complete
+20/20 95.0% complete
  
 A company notices performance degradation in one of its production web applications. The application is running on AWS services and uses a microservices architecture. The company suspects that one of these microservices is causing the performance issue.
 
@@ -1815,16 +1671,14 @@ Which AWS solution should the company use to identify the service that is contri
 
 Report Content Errors
 
-A
-AWS X-Ray service map
+A AWS X-Ray service map
 
 Correct. X-Ray creates a map of services used by your application with trace data. You can use the trace data to drill into specific services or issues. This data provides a view of connections between services in your application and aggregated data for each service, including average latency and failure rates.
 
 For more information about X-Ray, see AWS X-Ray features.
 
 
-B
-AWS CloudTrail event history
+B AWS CloudTrail event history
 
 Incorrect. CloudTrail event history is used to record API calls for governance, compliance operation, and risk auditing purposes. CloudTrail is not a service that is used for identifying application performance issues.
 
@@ -1833,8 +1687,7 @@ For more information about CloudTrail and its uses, see What Is AWS CloudTrail?
 For more information about CloudTrail event history, see Viewing Events with CloudTrail Event History.
 
 
-C
-Amazon EventBridge (Amazon CloudWatch Events) events
+C Amazon EventBridge (Amazon CloudWatch Events) events
 
 Incorrect. EventBridge (CloudWatch Events) delivers a near-real-time stream of system events that describe changes in Amazon Web Services resources. It is not used for identifying application performance issues.
 
@@ -1843,8 +1696,7 @@ For more information about EventBridge (CloudWatch Events), see What Is Amazon E
 For more information about EventBridge (CloudWatch Events) events, see Amazon EventBridge events.
 
 
-D
-AWS Trusted Advisor performance report
+D AWS Trusted Advisor performance report
 
 Incorrect. Trusted Advisor provides real-time guidance to help provision AWS resources to follow AWS best practices. It can report overall system utilization, but it is not used for identifying application performance issues.
 
@@ -1854,12 +1706,9 @@ For more information about Trusted Advisor, see AWS Trusted Advisor.
  
 # AWS 
  
-1.1 Design a multi-tier architecture solution
- This Question: 01:42
- Total: 01:42
+1.1 Design a multi-tier architecture solution This Question: 01:42 Total: 01:42
 
-1/20
-0.0% complete
+1/20 0.0% complete
  
 A solutions architect is designing a solution to run a containerized web application by using Amazon Elastic Container Service (Amazon ECS). The solutions architect wants to minimize cost by running multiple copies of a task on each container instance. The number of task copies must scale as the load increases and decreases.
 
@@ -1867,32 +1716,28 @@ Which routing solution distributes the load to the multiple tasks?
 
 Report Content Errors
 
-A
-Configure an Application Load Balancer to distribute the requests by using path-based routing.
+A Configure an Application Load Balancer to distribute the requests by using path-based routing.
 
 Incorrect. With path-based routing, multiple services can use the same listener port on a single Application Load Balancer (ALB). The ALB forwards requests to specific target groups based on the URL path. However, this solution does not help with load distribution between different tasks of the same service.
 
 For more information about load balancing, see Service load balancing.
 
 
-B
-Configure an Application Load Balancer to distribute the requests by using dynamic host port mapping.
+B Configure an Application Load Balancer to distribute the requests by using dynamic host port mapping.
 
 Correct. With dynamic host port mapping, multiple tasks from the same service are allowed for each container instance.
 
 For more information about load balancing, see Service load balancing.
 
 
-C
-Configure an Amazon Route 53 alias record set to distribute the requests with a failover routing policy.
+C Configure an Amazon Route 53 alias record set to distribute the requests with a failover routing policy.
 
 Incorrect. You can use failover routing policies to route traffic to backup instances, in case a primary instance fails. You cannot use failover routing policies to manage multiple tasks on a single container.
 
 For more information about routing policies, see Choosing a routing policy.
 
 
-D
-Configure an Amazon Route 53 alias record set to distribute the requests with a weighted routing policy.
+D Configure an Amazon Route 53 alias record set to distribute the requests with a weighted routing policy.
 
 Incorrect. You can use weighted routing policies to route traffic to instances at proportions that you specify. You cannot use weighted routing policies to manage multiple tasks on a single container.
 
@@ -1907,12 +1752,9 @@ B
 
 
  
-1.1 Design a multi-tier architecture solution
- This Question: 01:45
- Total: 03:28
+1.1 Design a multi-tier architecture solution This Question: 01:45 Total: 03:28
 
-2/20
-5.0% complete
+2/20 5.0% complete
  
 The usage of a company's image-processing application is increasing suddenly with no set pattern. The application's processing time grows linearly with the size of the image. The processing can take up to 20 minutes for large image files.
 
@@ -1922,8 +1764,7 @@ Which solution will meet these requirements?
 
 Report Content Errors
 
-A
-Purchase enough Dedicated Instances to meet the peak demand. Deploy the instances for the consumers.
+A Purchase enough Dedicated Instances to meet the peak demand. Deploy the instances for the consumers.
 
 Incorrect. With Dedicated Instances, you can reduce your costs by using existing server-bound software licenses. However, server-bound licenses are not mentioned in this scenario. One of the benefits of the AWS Cloud is that you do not have to purchase for peak consumption. The AWS Cloud can scale on demand.
 
@@ -1932,8 +1773,7 @@ For more information about Dedicated Hosts, see Amazon EC2 Dedicated Hosts Prici
 For more information about demand-based scaling, see Dynamic Supply.
 
 
-B
-Convert the existing SQS standard queue to an SQS FIFO queue. Increase the visibility timeout.
+B Convert the existing SQS standard queue to an SQS FIFO queue. Increase the visibility timeout.
 
 Incorrect. FIFO queues will solve problems that occur when messages are processed out of order. FIFO queues will not improve performance during sudden volume increases. Additionally, you cannot convert SQS queues after you create them.
 
@@ -1942,28 +1782,23 @@ For more information about FIFO queues, see Amazon SQS FIFO (First-In-First-Out)
 For more information about SQS queues, see Editing an Amazon SQS queue (console).
 
 
-C
-Configure a scalable AWS Lambda function as the consumer of the SQS messages.
+C Configure a scalable AWS Lambda function as the consumer of the SQS messages.
 
 Incorrect. Some files in this scenario can take up to 20 minutes to process. Lambda has a 15-minute operational limit.
 
 For more information about Lambda constraints, see Lambda quotas.
 
 
-D
-Create a message consumer that is an Auto Scaling group of instances. Configure the Auto Scaling group to scale based upon the ApproximateNumberOfMessages Amazon CloudWatch metric.
+D Create a message consumer that is an Auto Scaling group of instances. Configure the Auto Scaling group to scale based upon the ApproximateNumberOfMessages Amazon CloudWatch metric.
 
 Correct. With Amazon EC2 Auto Scaling, the processing capacity can keep up with the demand.
 
 For more information about the use of Amazon EC2 Auto Scaling with Amazon SQS, see Scaling based on Amazon SQS.
 
 
-1.2 Design highly available and/or fault-tolerant architectures
- This Question: 00:53
- Total: 04:21
+1.2 Design highly available and/or fault-tolerant architectures This Question: 00:53 Total: 04:21
 
-3/20
-10.0% complete
+3/20 10.0% complete
  
 An application runs on two Amazon EC2 instances behind a Network Load Balancer. The EC2 instances are in a single Availability Zone.
 
@@ -1971,32 +1806,28 @@ What should a solutions architect do to make this architecture more highly avail
 
 Report Content Errors
 
-A
-Create a new VPC with two new EC2 instances in the same Availability Zone as the original EC2 instances. Create a VPC peering connection between the two VPCs
+A Create a new VPC with two new EC2 instances in the same Availability Zone as the original EC2 instances. Create a VPC peering connection between the two VPCs
 
 Incorrect. VPC peering will provide connectivity to the other Availability Zone. However, VPC peering does not ensure high availability because the EC2 instances are still in one Availability Zone.
 
 For more information about VPC peering, see What is VPC Peering?
 
 
-B
-Replace the Network Load Balancer with an Application Load Balancer that is configured with the EC2 instances in an Auto Scaling group.
+B Replace the Network Load Balancer with an Application Load Balancer that is configured with the EC2 instances in an Auto Scaling group.
 
 Incorrect. The replacement of the Network Load Balancer with an Application Load Balancer provides no additional availability. Both load balancers are inherently highly available. However, the EC2 instances would be highly available only if they extended across two Availability Zones.
 
 For more information about Elastic Load Balancing, see How Elastic Load Balancing works.
 
 
-C
-Configure Amazon Route 53 to perform health checks on the EC2 instances behind the Network Load Balancer. Add a failover routing policy.
+C Configure Amazon Route 53 to perform health checks on the EC2 instances behind the Network Load Balancer. Add a failover routing policy.
 
 Incorrect. Failover routing requires a primary destination and a secondary (failover) destination. No failover destination is specified in this solution. In addition, this approach does not ensure high availability because the EC2 instances are still in one Availability Zone.
 
 For more information about DNS failover, see Configuring DNS failover.
 
 
-D
-Place the EC2 instances in an Auto Scaling group that extends across multiple Availability Zones. Designate the Auto Scaling group as the target of the Network Load Balancer.
+D Place the EC2 instances in an Auto Scaling group that extends across multiple Availability Zones. Designate the Auto Scaling group as the target of the Network Load Balancer.
 
 Correct. This solution extends the EC2 instances across multiple Availability Zones and automatically adds capacity when additional capacity is needed.
 
@@ -2011,12 +1842,9 @@ D
 
 
  
-1.4 Choose appropriate resilient storage
- This Question: 00:56
- Total: 05:17
+1.4 Choose appropriate resilient storage This Question: 00:56 Total: 05:17
 
-4/20
-15.0% complete
+4/20 15.0% complete
  
 A company is using an Amazon S3 bucket to store legal documents. The company frequently revises the documents and re-uploads them with the same object key to the S3 bucket. The company needs the ability to download older copies of the documents. The company also needs to protect the documents from accidental deletion.
 
@@ -2024,32 +1852,28 @@ What is the MOST operationally efficient solution that meets these requirements?
 
 Report Content Errors
 
-A
-Enable S3 Versioning on the S3 bucket.
+A Enable S3 Versioning on the S3 bucket.
 
 Correct. With S3 Versioning, you can keep multiple variants of an object in the same S3 bucket. You can use S3 Versioning to preserve, retrieve, and restore every version of every object that is stored in your S3 bucket. By using S3 Versioning, you can recover from unintended user actions and application failures.
 
 For more information about S3 Versioning, see How S3 Versioning works.
 
 
-B
-Enable multi-factor authentication (MFA) delete on the S3 bucket.
+B Enable multi-factor authentication (MFA) delete on the S3 bucket.
 
 Incorrect. MFA delete provides an additional layer of object security. MFA delete ensures that the entity that deletes the objects possesses an authorized MFA token. However, MFA delete does not meet the document versioning requirements of this question.
 
 For more information about MFA delete, see Configuring MFA delete.
 
 
-C
-Configure S3 Cross-Region Replication from the S3 bucket to an S3 bucket in a different AWS Region.
+C Configure S3 Cross-Region Replication from the S3 bucket to an S3 bucket in a different AWS Region.
 
 Incorrect. S3 Cross-Region Replication requires S3 Versioning as a prerequisite. However, S3 Versioning alone meets the requirements of this question and is the more operationally efficient solution.
 
 For information about S3 Cross-Region Replication, see Replicating objects.
 
 
-D
-Configure an S3 Lifecycle policy to archive the documents to S3 Glacier after 30 days.
+D Configure an S3 Lifecycle policy to archive the documents to S3 Glacier after 30 days.
 
 Incorrect. You can use S3 Lifecycle rules to store objects cost-effectively throughout their lifecycle. S3 Lifecycle rules do not meet the document versioning requirements of this question.
 
@@ -2064,12 +1888,9 @@ A
 
 
  
-2.1 Identify elastic and scalable compute solutions for a workload
- This Question: 00:50
- Total: 06:07
+2.1 Identify elastic and scalable compute solutions for a workload This Question: 00:50 Total: 06:07
 
-5/20
-20.0% complete
+5/20 20.0% complete
  
 A reporting application runs on Amazon EC2 instances behind an Application Load Balancer. The instances run in an Amazon EC2 Auto Scaling group across multiple Availability Zones. For complex reports, the application can take up to 15 minutes to respond to a request. A solutions architect is concerned that users will receive HTTP 5xx errors if a report request is in process during a scale-in event.
 
@@ -2077,32 +1898,28 @@ What should the solutions architect do to ensure that user requests will be comp
 
 Report Content Errors
 
-A
-Enable sticky sessions (session affinity) for the target group of the instances.
+A Enable sticky sessions (session affinity) for the target group of the instances.
 
 Incorrect. If an EC2 instance were removed from the target group during a scale-in process, the EC2 instance would fail (or would be unhealthy if it were checked). An Application Load Balancer would stop routing requests to that target and would choose a new healthy target.
 
 For more information about sticky sessions, see Sticky sessions for your Application Load Balancer.
 
 
-B
-Increase the instance size in the Application Load Balancer target group.
+B Increase the instance size in the Application Load Balancer target group.
 
 Incorrect. An increase of the instance size likely would increase the speed of processing. However, this solution does not directly ensure that instances that process a request are unaffected by scale-in actions.
 
 For more information about deregistration delay, see Deregistration delay.
 
 
-C
-Increase the cooldown period for the Auto Scaling group to a greater amount of time than the time required for the longest running responses.
+C Increase the cooldown period for the Auto Scaling group to a greater amount of time than the time required for the longest running responses.
 
 Incorrect. Amazon EC2 Auto Scaling cooldown periods help you prevent Auto Scaling groups from launching or terminating additional instances before the effects of previous activities are apparent.
 
 For more information about cooldown periods, see Scaling cooldowns for Amazon EC2 Auto Scaling.
 
 
-D
-Increase the deregistration delay timeout for the target group of the instances to greater than 900 seconds.
+D Increase the deregistration delay timeout for the target group of the instances to greater than 900 seconds.
 
 Correct. By default, Elastic Load Balancing waits 300 seconds before the completion of the deregistration process, which can help in-flight requests to the target become complete. To change the amount of time that Elastic Load Balancing waits, update the deregistration delay value.
 
@@ -2117,12 +1934,9 @@ D
 
 
  
-2.1 Identify elastic and scalable compute solutions for a workload
- This Question: 00:39
- Total: 06:47
+2.1 Identify elastic and scalable compute solutions for a workload This Question: 00:39 Total: 06:47
 
-6/20
-25.0% complete
+6/20 25.0% complete
  
 A company used Amazon EC2 Spot Instances for a demonstration that is now complete. A solutions architect must remove the Spot Instances to stop them from incurring cost.
 
@@ -2130,32 +1944,28 @@ What should the solutions architect do to meet this requirement?
 
 Report Content Errors
 
-A
-Cancel the Spot request only.
+A Cancel the Spot request only.
 
 Incorrect. If the only action you take is to cancel the Spot request, the running instances will not be terminated automatically. These instances will continue to run and will incur additional cost.
 
 For more information about the termination of Spot Instances, see Terminate a Spot Instance.
 
 
-B
-Terminate the Spot Instances only.
+B Terminate the Spot Instances only.
 
 Incorrect. When Spot Instances are terminated, new instances will launch until the Spot request is canceled.
 
 For more information about the termination of Spot Instances, see Terminate a Spot Instance.
 
 
-C
-Cancel the Spot request. Terminate the Spot Instances.
+C Cancel the Spot request. Terminate the Spot Instances.
 
 Correct. To remove the Spot Instances, the appropriate steps are to cancel the Spot request and then to terminate the Spot Instances.
 
 For more information about the termination of Spot Instances, see Terminate a Spot Instance.
 
 
-D
-Terminate the Spot Instances. Cancel the Spot request.
+D Terminate the Spot Instances. Cancel the Spot request.
 
 Incorrect. When Spot Instances are terminated, new instances will launch until the Spot request is canceled.
 
@@ -2170,12 +1980,9 @@ C
 
 
  
-2.1 Identify elastic and scalable compute solutions for a workload
- This Question: 00:41
- Total: 07:28
+2.1 Identify elastic and scalable compute solutions for a workload This Question: 00:41 Total: 07:28
 
-7/20
-30.0% complete
+7/20 30.0% complete
  
 A company needs to look up configuration details about how a Linux-based Amazon EC2 instance was launched.
 
@@ -2183,32 +1990,28 @@ Which command should a solutions architect run on the EC2 instance to gather the
 
 Report Content Errors
 
-A
-curl http://169.254.169.254/latest/meta-data
+A curl http://169.254.169.254/latest/meta-data
 
 Correct. The only way to retrieve instance metadata is to use the link-local address, which is 169.254.169.254.
 
 For more information about instance metadata, see Retrieve instance metadata.
 
 
-B
-curl http://localhost/latest/meta-data
+B curl http://localhost/latest/meta-data
 
 Incorrect. The use of localhost will not work because this solution checks an IP address of 127.0.0.1. Metadata is not available through the use of the localhost name.
 
 For more information about instance metadata, see Retrieve instance metadata.
 
 
-C
-curl http://254.169.254.169/latest/meta-data
+C curl http://254.169.254.169/latest/meta-data
 
 Incorrect. The format for the link-local address is 169.254.169.254.
 
 For more information about instance metadata, see Retrieve instance metadata.
 
 
-D
-curl http://192.168.0.1/latest/meta-data
+D curl http://192.168.0.1/latest/meta-data
 
 Incorrect. The 192.168.x.x. IP address range is a public block. Instance metadata is not available through a public block.
 
@@ -2223,12 +2026,9 @@ A
 
 
  
-2.2 Select high-performing and scalable storage solutions for a workload
- This Question: 01:00
- Total: 08:29
+2.2 Select high-performing and scalable storage solutions for a workload This Question: 01:00 Total: 08:29
 
-8/20
-35.0% complete
+8/20 35.0% complete
  
 A company has an on-premises application that exports log files about users of a website. These log files range from 20 GB to 30 GB in size. A solutions architect has created an Amazon S3 bucket to store these files. The files will be uploaded directly from the application. The network connection experiences intermittent failures, and the upload sometimes fails.
 
@@ -2238,32 +2038,28 @@ Which solution will meet these requirements?
 
 Report Content Errors
 
-A
-Enable S3 Transfer Acceleration.
+A Enable S3 Transfer Acceleration.
 
 Incorrect. S3 Transfer Acceleration facilitates quicker uploads by using edge locations to copy data into Amazon S3. S3 Transfer Acceleration does not solve the problem of the file size limitation (5 GB) for a single PUT operation.
 
 For more information about S3 Transfer Acceleration, see S3 Transfer Acceleration.
 
 
-B
-Copy the files to an Amazon EC2 instance in the closest AWS Region. Use S3 Lifecycle policies to copy the log files to Amazon S3.
+B Copy the files to an Amazon EC2 instance in the closest AWS Region. Use S3 Lifecycle policies to copy the log files to Amazon S3.
 
 Incorrect. This solution does not solve the problem of the file size limitation (5 GB) for a single PUT operation. S3 Lifecycle policies cannot transfer files from EC2 block storage to Amazon S3. This solution also adds unnecessary services and operational overhead to the environment.
 
 For more information about Amazon EC2, see What is Amazon EC2?
 
 
-C
-Use multipart upload to Amazon S3.
+C Use multipart upload to Amazon S3.
 
 Correct. With a single PUT operation, you can upload a single object that is up to 5 GB in size. You can use a multipart upload to upload larger files, such as the files in this scenario.
 
 For more information about multipart uploads, see Uploading and copying objects using multipart upload.
 
 
-D
-Upload the files to two AWS Regions simultaneously. Enable two-way Cross-Region Replication between the two Regions.
+D Upload the files to two AWS Regions simultaneously. Enable two-way Cross-Region Replication between the two Regions.
 
 Incorrect. This solution does not solve the problem of the file size limitation (5 GB) for a single PUT operation. Each destination Region would have the same problem as a single Region. This solution also adds operational overhead.
 
@@ -2278,12 +2074,9 @@ C
 
 
  
-2.2 Select high-performing and scalable storage solutions for a workload
- This Question: 00:27
- Total: 08:56
+2.2 Select high-performing and scalable storage solutions for a workload This Question: 00:27 Total: 08:56
 
-9/20
-40.0% complete
+9/20 40.0% complete
  
 A company is deploying a new database on a new Amazon EC2 instance. The workload of this database requires a single Amazon Elastic Block Store (Amazon EBS) volume that can support up to 20,000 IOPS.
 
@@ -2291,32 +2084,28 @@ Which type of EBS volume meets this requirement?
 
 Report Content Errors
 
-A
-Throughput Optimized HDD
+A Throughput Optimized HDD
 
 Incorrect. A Throughput Optimized HDD EBS volume is an HDD-backed storage device that is limited to 500 IOPS for each volume.
 
 For more information about Throughput Optimized HDD EBS volumes, see Hard disk drives (HDD).
 
 
-B
-Provisioned IOPS SSD
+B Provisioned IOPS SSD
 
 Correct. A Provisioned IOPS SSD EBS volume provides up to 64,000 IOPS for each volume.
 
 For more information about Provisioned IOPS SSD EBS volumes, see Solid state drives (SSD).
 
 
-C
-General Purpose SSD
+C General Purpose SSD
 
 Incorrect. A General Purpose SSD EBS volume is limited to 16,000 IOPS for each volume.
 
 For more information about General Purpose SSD EBS volumes, see Solid state drives (SSD).
 
 
-D
-Cold HDD
+D Cold HDD
 
 Incorrect. A Cold HDD volume provides low-cost magnetic storage that defines performance in terms of throughput rather than IOPS. Cold HDD volumes are a good fit for large, sequential cold-data workloads.
 
@@ -2331,27 +2120,22 @@ B
 
 
  
-2.3 Select high-performing networking solutions for a workload
- This Question: 00:29
- Total: 09:26
+2.3 Select high-performing networking solutions for a workload This Question: 00:29 Total: 09:26
 
-10/20
-45.0% complete
+10/20 45.0% complete
  
 Which components are required to build a site-to-site VPN connection on AWS? (Select TWO.)
 
 Report Content Errors
 
-A
-An internet gateway
+A An internet gateway
 
 Incorrect. An internet gateway is attached to a VPC to allow traffic from the internet to flow into or out of the VPC. A VPN connection does not flow through an internet gateway. The internet gateway is designed to allow traffic from the open internet, not an encrypted VPN connection.
 
 For more information about internet gateways, see Internet gateways.
 
 
-B
-A NAT gateway
+B A NAT gateway
 
 Incorrect. A NAT gateway provides a way for private Amazon EC2 instances to send requests to the internet. A NAT gateway does not give you the ability to create an encrypted site-to-site VPN connection.
 
@@ -2360,24 +2144,21 @@ For more information about NAT gateways, see NAT gateways.
 For more information about VPN connections to AWS, see What is AWS Site-to-Site VPN?
 
 
-C
-A customer gateway
+C A customer gateway
 
 Correct. A customer gateway is required for the VPN connection to be established. A customer gateway device is set up and configured in the customer's data center.
 
 For more information about customer gateways and VPN connections to AWS, see What is AWS Site-to-Site VPN?
 
 
-D
-Amazon API Gateway
+D Amazon API Gateway
 
 Incorrect. API Gateway is a fully managed service for developers to create, publish, maintain, monitor, and secure APIs at any scale. APIs act as the front door for applications to use to access data, business logic, or functionality from backend services. However, API Gateway is not necessary for the implementation of a VPN connection.
 
 For more information about API Gateway, see What is Amazon API Gateway?
 
 
-E
-A virtual private gateway
+E A virtual private gateway
 
 Correct. A virtual private gateway is attached to a VPC to create a site-to-site VPN connection on AWS. You can accept private encrypted network traffic from an on-premises data center into your VPC without the need to traverse the open public internet.
 
@@ -2392,12 +2173,9 @@ CE
 
 
  
-2.4 Choose high-performing database solutions for a workload
- This Question: 00:35
- Total: 10:02
+2.4 Choose high-performing database solutions for a workload This Question: 00:35 Total: 10:02
 
-11/20
-50.0% complete
+11/20 50.0% complete
  
 A company is developing a chat application that will be deployed on AWS. The application stores the messages by using a key-value data model. Groups of users typically read the messages multiple times. A solutions architect must select a database solution that will scale for a high rate of reads and will deliver messages with microsecond latency.
 
@@ -2405,16 +2183,14 @@ Which database solution will meet these requirements?
 
 Report Content Errors
 
-A
-Amazon Aurora with Aurora Replicas
+A Amazon Aurora with Aurora Replicas
 
 Incorrect. Aurora is a relational database (not a key-value database). Aurora is not likely to achieve microsecond latency consistently.
 
 For more information about Aurora, see What is Amazon Aurora?
 
 
-B
-Amazon DynamoDB with DynamoDB Accelerator (DAX)
+B Amazon DynamoDB with DynamoDB Accelerator (DAX)
 
 Correct. DynamoDB is a NoSQL database that supports key-value records. DAX delivers response times in microseconds.
 
@@ -2423,8 +2199,7 @@ For more information about DynamoDB, see What is Amazon DynamoDB?
 For more information about DAX, see In-Memory Acceleration with DynamoDB Accelerator (DAX).
 
 
-C
-Amazon Aurora with Amazon ElastiCache for Memcached
+C Amazon Aurora with Amazon ElastiCache for Memcached
 
 Incorrect. Aurora is a relational database (not a key-value database). Aurora is not likely to achieve microsecond latency consistently, even with ElastiCache.
 
@@ -2433,8 +2208,7 @@ For more information about Aurora, see What is Amazon Aurora?
 For more information about ElastiCache for Memcached, see What is Amazon ElastiCache for Memcached?
 
 
-D
-Amazon Neptune with Amazon ElastiCache for Memcached
+D Amazon Neptune with Amazon ElastiCache for Memcached
 
 Incorrect. Neptune is a graph database that is optimized for working with highly connected data. Neptune is not optimized for simple key-value data.
 
@@ -2449,12 +2223,9 @@ B
 
 
  
-3.1 Design secure access to AWS resources
- This Question: 00:57
- Total: 11:00
+3.1 Design secure access to AWS resources This Question: 00:57 Total: 11:00
 
-12/20
-55.0% complete
+12/20 55.0% complete
  
 A company uses one AWS account to run production workloads. The company has a separate AWS account for its security team. During periodic audits, the security team needs to view specific account settings and resource configurations in the AWS account that runs production workloads. A solutions architect must provide the required access to the security team by designing a solution that follows AWS security best practices.
 
@@ -2462,32 +2233,28 @@ Which solution will meet these requirements?
 
 Report Content Errors
 
-A
-Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to each user.
+A Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to each user.
 
 Incorrect. This solution does not follow the security best practice of using roles to delegate permissions.
 
 For more information about how to use roles to delegate permissions, see Use roles to delegate permissions.
 
 
-B
-Create an IAM role in the production account. Attach a permissions policy that provides the permissions required by the security team. Add the security team account to the trust policy.
+B Create an IAM role in the production account. Attach a permissions policy that provides the permissions required by the security team. Add the security team account to the trust policy.
 
 Correct. This solution follows security best practices by using a role to delegate permissions that consist of least privilege access.
 
 For more information about how to use roles to delegate permissions, see Use roles to delegate permissions.
 
 
-C
-Create a new IAM user in the production account. Assign administrative privileges to the user. Allow the security team to use this account to log in to the systems that need to be accessed.
+C Create a new IAM user in the production account. Assign administrative privileges to the user. Allow the security team to use this account to log in to the systems that need to be accessed.
 
 Incorrect. The assignment of administrative privileges to a user violates security best practices and the principle of least privilege.
 
 For more information about how to grant least privilege in roles, see Grant least privilege.
 
 
-D
-Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to a new IAM group. Assign the security team members to the group.
+D Create an IAM user for each security team member in the production account. Attach a permissions policy that provides the permissions required by the security team to a new IAM group. Assign the security team members to the group.
 
 Incorrect. This solution does not follow the security best practice of using roles to delegate permissions.
 
@@ -2502,12 +2269,9 @@ B
 
 
  
-3.1 Design secure access to AWS resources
- This Question: 00:31
- Total: 11:31
+3.1 Design secure access to AWS resources This Question: 00:31 Total: 11:31
 
-13/20
-60.0% complete
+13/20 60.0% complete
  
 A company is developing a new mobile version of its popular web application in the AWS Cloud. The mobile app must be accessible to internal and external users. The mobile app must handle authorization, authentication, and user management from one central source.
 
@@ -2515,16 +2279,14 @@ Which solution meets these requirements?
 
 Report Content Errors
 
-A
-IAM roles
+A IAM roles
 
 Incorrect. An IAM role is an IAM entity that is assumable by an IAM user. An IAM role has permissions policies that define what the entity can and cannot do. However, an IAM role does not control access to an application.
 
 For more information about IAM roles, see IAM roles.
 
 
-B
-IAM users and groups
+B IAM users and groups
 
 Incorrect. You can use IAM users and groups to control who is authenticated and authorized to use an AWS service. However, users and groups do not control access to an application.
 
@@ -2533,16 +2295,14 @@ For more information about IAM users, see IAM users.
 For more information about IAM groups, see IAM groups.
 
 
-C
-Amazon Cognito user pools
+C Amazon Cognito user pools
 
 Correct. Amazon Cognito provides authentication, authorization, and user management for your web and mobile apps. Users can sign in directly with a user name and password, or through a trusted third party.
 
 For more information about Amazon Cognito, see What is Amazon Cognito?
 
 
-D
-AWS Security Token Service (AWS STS)
+D AWS Security Token Service (AWS STS)
 
 Incorrect. You can use AWS STS to create and provide trusted users with temporary security credentials that can control access to your AWS resources. However, AWS STS does not control access to an application.
 
@@ -2557,12 +2317,9 @@ C
 
 
  
-3.2 Design secure application tiers
- This Question: 00:58
- Total: 12:29
+3.2 Design secure application tiers This Question: 00:58 Total: 12:29
 
-14/20
-65.0% complete
+14/20 65.0% complete
  
 A company has strict data protection requirements. A solutions architect must configure security for a VPC to ensure that backend Amazon RDS DB instances cannot be accessed from the internet. The solutions architect must ensure that the DB instances are accessible from the application tier over a specified port only.
 
@@ -2570,40 +2327,35 @@ Which actions should the solutions architect take to meet these requirements? (S
 
 Report Content Errors
 
-A
-Specify a DB subnet group that contains only private subnets for the DB instances.
+A Specify a DB subnet group that contains only private subnets for the DB instances.
 
 Correct. A private subnet is one component to use to secure the database tier. Internet traffic is not routed to a private subnet. When you place DB instances in a private subnet, you add a layer of security.
 
 For more information about VPCs with public subnets and private subnets, see Routing.
 
 
-B
-Attach an elastic network interface with a private IPv4 address to each DB instance.
+B Attach an elastic network interface with a private IPv4 address to each DB instance.
 
 Incorrect. An elastic network interface is a logical networking component in a VPC that represents a virtual network card. The use of an elastic network interface would not meet the requirements in the scenario.
 
 For more information about elastic network interfaces, see Elastic network interfaces.
 
 
-C
-Configure AWS Shield with the VPC. Update the route tables for the subnets that the DB instances use.
+C Configure AWS Shield with the VPC. Update the route tables for the subnets that the DB instances use.
 
 Incorrect. Shield provides protection against DDoS attacks. Shield cannot be a target of routes in a route table. The use of Shield would not meet the requirements in the scenario.
 
 For more information about Shield, see AWS Shield.
 
 
-D
-Configure an AWS Direct Connect connection on the database port between the application tier and the backend.
+D Configure an AWS Direct Connect connection on the database port between the application tier and the backend.
 
 Incorrect. Direct Connect provides a dedicated connection to your AWS environment. The use of Direct Connect would not meet the requirements in the scenario.
 
 For more information about Direct Connect, see AWS Direct Connect features.
 
 
-E
-Add an inbound rule to the database security group that allows requests from the security group of the application tier over the database port. Remove other inbound rules.
+E Add an inbound rule to the database security group that allows requests from the security group of the application tier over the database port. Remove other inbound rules.
 
 Correct. Security groups can restrict access to the DB instances. Security groups provide access from only the application tier on only a specific port.
 
@@ -2618,12 +2370,9 @@ AE
 
 
  
-3.3 Select appropriate data security options
- This Question: 01:00
- Total: 13:30
+3.3 Select appropriate data security options This Question: 01:00 Total: 13:30
 
-15/20
-70.0% complete
+15/20 70.0% complete
  
 A company runs its website on Amazon EC2 instances behind an Application Load Balancer that is configured as the origin for an Amazon CloudFront distribution. The company wants to protect against cross-site scripting and SQL injection attacks.
 
@@ -2631,32 +2380,28 @@ Which approach should a solutions architect recommend to meet these requirements
 
 Report Content Errors
 
-A
-Enable AWS Shield Advanced. List the CloudFront distribution as a protected resource.
+A Enable AWS Shield Advanced. List the CloudFront distribution as a protected resource.
 
 Incorrect. Shield Advanced protects against DDoS attacks. Shield Advanced does not protect against cross-site scripting or SQL injection.
 
 For more information about Shield Advanced, see AWS Shield.
 
 
-B
-Define an AWS Shield Advanced policy in AWS Firewall Manager to block cross-site scripting and SQL injection attacks.
+B Define an AWS Shield Advanced policy in AWS Firewall Manager to block cross-site scripting and SQL injection attacks.
 
 Incorrect. With Firewall Manager, you can manage AWS WAF, Shield Advanced, and other AWS services. Shield Advanced protects against DDoS attacks. Shield Advanced does not protect against cross-site scripting or SQL injection.
 
 For more information about AWS WAF, AWS Shield, and Firewall Manager, see What are AWS WAF, AWS Shield, and AWS Firewall Manager?
 
 
-C
-Set up AWS WAF on the CloudFront distribution. Use conditions and rules that block cross-site scripting and SQL injection attacks.
+C Set up AWS WAF on the CloudFront distribution. Use conditions and rules that block cross-site scripting and SQL injection attacks.
 
 Correct. AWS WAF can detect the presence of SQL code that is likely to be malicious (known as SQL injection). AWS WAF also can detect the presence of a script that is likely to be malicious (known as cross-site scripting).
 
 For more information about AWS WAF, see AWS WAF.
 
 
-D
-Deploy AWS Firewall Manager on the EC2 instances. Create conditions and rules that block cross-site scripting and SQL injection attacks.
+D Deploy AWS Firewall Manager on the EC2 instances. Create conditions and rules that block cross-site scripting and SQL injection attacks.
 
 Incorrect. With Firewall Manager, you can manage AWS WAF, AWS Shield Advanced, and other AWS services. Firewall Manager is a managed service that is not installed on EC2 instances.
 
@@ -2671,12 +2416,9 @@ C
 
 
  
-4.1 Identify cost-effective storage solutions
- This Question: 01:19
- Total: 14:50
+4.1 Identify cost-effective storage solutions This Question: 01:19 Total: 14:50
 
-16/20
-75.0% complete
+16/20 75.0% complete
  
 A solutions architect is planning a company's migration to the AWS Cloud. A key component of the company's environment is an application server that sends email notifications to customers. As part of this migration, the solutions architect must use only managed AWS services.
 
@@ -2684,32 +2426,28 @@ Which solution meets these requirements?
 
 Report Content Errors
 
-A
-Configure Amazon Simple Queue Service (Amazon SQS) with a standard queue.
+A Configure Amazon Simple Queue Service (Amazon SQS) with a standard queue.
 
 Incorrect. Amazon SQS is a fully managed message queuing service that sends messages between software components. However, Amazon SQS cannot push messages to customers.
 
 For information about Amazon SQS, see Amazon Simple Queue Service.
 
 
-B
-Deploy an Amazon EC2 instance to host the application server. Send email notifications.
+B Deploy an Amazon EC2 instance to host the application server. Send email notifications.
 
 Incorrect. The deployment of an EC2 instance gives the company the ability to run its application. However, this solution does not use only managed services.
 
 For more information about Amazon EC2, see Amazon EC2.
 
 
-C
-Configure Amazon Simple Queue Service (Amazon SQS) with a FIFO queue.
+C Configure Amazon Simple Queue Service (Amazon SQS) with a FIFO queue.
 
 Incorrect. Amazon SQS is a fully managed message queuing service that sends messages between software components. However, Amazon SQS cannot push messages to customers.
 
 For information about Amazon SQS, see Amazon Simple Queue Service.
 
 
-D
-Configure Amazon Simple Notification Service (Amazon SNS) with the protocol of email.
+D Configure Amazon Simple Notification Service (Amazon SNS) with the protocol of email.
 
 Correct. Amazon SNS is a fully managed messaging service for application-to-application communication and application-to-person communication.
 
@@ -2724,12 +2462,9 @@ D
 
 
  
-4.1 Identify cost-effective storage solutions
- This Question: 00:42
- Total: 15:32
+4.1 Identify cost-effective storage solutions This Question: 00:42 Total: 15:32
 
-17/20
-80.0% complete
+17/20 80.0% complete
  
 A company needs to maintain data records for a minimum of 5 years. The data is rarely accessed after it is stored. The data must be accessible within 2 hours.
 
@@ -2737,16 +2472,14 @@ Which solution will meet these requirements MOST cost-effectively?
 
 Report Content Errors
 
-A
-Store the data in an Amazon Elastic File System (Amazon EFS) file system. Access the data by using AWS Direct Connect.
+A Store the data in an Amazon Elastic File System (Amazon EFS) file system. Access the data by using AWS Direct Connect.
 
 Incorrect. This solution is not the most cost-effective solution. Amazon S3 is a more cost-effective solution if there is not a requirement for a file system.
 
 For more information about Amazon EFS and Direct Connect, see How Amazon EFS works with AWS Direct Connect and AWS Managed VPN.
 
 
-B
-Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Glacier.
+B Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Glacier.
 
 Correct. The storage of the data in an S3 bucket provides a cost-effective initial location for the data. S3 Glacier is the most cost-effective archival storage solution that meets the requirement of a 2-hour retrieval time.
 
@@ -2755,16 +2488,14 @@ For more information about how to move data between S3 storage classes automatic
 For more information about S3 storage classes, see Using Amazon S3 storage classes.
 
 
-C
-Store the data in an Amazon Elastic Block Store (Amazon EBS) volume. Create snapshots. Store the snapshots in an Amazon S3 bucket.
+C Store the data in an Amazon Elastic Block Store (Amazon EBS) volume. Create snapshots. Store the snapshots in an Amazon S3 bucket.
 
 Incorrect. This solution is not the most cost-effective solution because it requires the use of Amazon EBS in addition to Amazon S3.
 
 For more information about EBS snapshots, see Amazon EBS snapshots.
 
 
-D
-Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Standard-Infrequent Access (S3 Standard-IA).
+D Store the data in an Amazon S3 bucket. Use an S3 Lifecycle policy to move the data to S3 Standard-Infrequent Access (S3 Standard-IA).
 
 Incorrect. The storage of the data in an S3 bucket provides a cost-effective initial location for the data. However, S3 Standard-IA is not the most cost-effective storage class to meet the requirements in the scenario. The S3 Glacier storage class is designed for low-cost data archiving.
 
@@ -2779,12 +2510,9 @@ B
 
 
  
-4.1 Identify cost-effective storage solutions
- This Question: 00:42
- Total: 16:15
+4.1 Identify cost-effective storage solutions This Question: 00:42 Total: 16:15
 
-18/20
-85.0% complete
+18/20 85.0% complete
  
 A media company is designing a new solution for graphic rendering. The application requires up to 400 GB of storage for temporary data that is discarded after the frames are rendered. The application requires approximately 40,000 random IOPS to perform the rendering.
 
@@ -2792,16 +2520,14 @@ What is the MOST cost-effective storage option for this rendering application?
 
 Report Content Errors
 
-A
-A storage optimized Amazon EC2 instance with instance store storage
+A A storage optimized Amazon EC2 instance with instance store storage
 
 Correct. SSD-Backed Storage Optimized (i2) instances provide more than 365,000 random IOPS. The instance store has no additional cost, compared with the regular hourly cost of the instance.
 
 For more information about pricing for EC2 instances, see Amazon EC2 pricing.
 
 
-B
-A storage optimized Amazon EC2 instance with a Provisioned IOPS SSD (io1 or io2) Amazon Elastic Block Store (Amazon EBS) volume
+B A storage optimized Amazon EC2 instance with a Provisioned IOPS SSD (io1 or io2) Amazon Elastic Block Store (Amazon EBS) volume
 
 Incorrect. Provisioned IOPS SSD (io1 or io2) EBS volumes can deliver more than the 40,000 IOPS that are required in the scenario. However, this solution is not as cost-effective as an instance store because Amazon EBS adds cost to the hourly instance rate. This solution provides persistence of data beyond the lifecycle of the instance, but persistence is not required in this use case.
 
@@ -2810,8 +2536,7 @@ For more information about Provisioned IOPS SSD (io1 or io2) EBS volumes, see Pr
 For more information about pricing for Amazon EBS, see Amazon EBS pricing.
 
 
-C
-A burstable Amazon EC2 instance with a Throughput Optimized HDD (st1) Amazon Elastic Block Store (Amazon EBS) volume
+C A burstable Amazon EC2 instance with a Throughput Optimized HDD (st1) Amazon Elastic Block Store (Amazon EBS) volume
 
 Incorrect. Throughput Optimized HDD (st1) EBS volumes are engineered to maximize the throughput of data that can be sent to and from a volume, not the random IOPS. Consequently, this solution does not meet the IOPS requirement. In addition, Amazon EBS adds cost to the hourly instance rate. This solution provides persistence of data beyond the lifecycle of the instance, but persistence is not required in this use case.
 
@@ -2820,8 +2545,7 @@ For more information about Throughput Optimized HDD (st1) EBS volumes, see Throu
 For more information about pricing for Amazon EBS, see Amazon EBS pricing.
 
 
-D
-A burstable Amazon EC2 instance with Amazon S3 storage over a VPC endpoint
+D A burstable Amazon EC2 instance with Amazon S3 storage over a VPC endpoint
 
 Incorrect. The rapidly changing data that is required for the scratch volume space makes Amazon S3 (object storage) the wrong storage. Block storage is appropriate for the read/write functionality to work smoothly.
 
@@ -2834,12 +2558,9 @@ A
 
 
  
-4.2 Identify cost-effective compute and database services
- This Question: 01:00
- Total: 17:15
+4.2 Identify cost-effective compute and database services This Question: 01:00 Total: 17:15
 
-19/20
-90.0% complete
+19/20 90.0% complete
  
 A company is deploying a new application that will consist of an application layer and an online transaction processing (OLTP) relational database. The application must be available at all times. However, the application will have periods of inactivity. The company wants to pay the minimum for compute costs during these idle periods.
 
@@ -2847,8 +2568,7 @@ Which solution meets these requirements MOST cost-effectively?
 
 Report Content Errors
 
-A
-Run the application in containers with Amazon Elastic Container Service (Amazon ECS) on AWS Fargate. Use Amazon Aurora Serverless for the database.
+A Run the application in containers with Amazon Elastic Container Service (Amazon ECS) on AWS Fargate. Use Amazon Aurora Serverless for the database.
 
 Correct. When Amazon ECS uses Fargate for compute, it incurs no costs when the application is idle. Aurora Serverless also incurs no compute costs when it is idle.
 
@@ -2857,24 +2577,21 @@ For more information about Fargate, see AWS Fargate Pricing.
 For more information about Aurora Serverless, see Amazon Aurora Serverless.
 
 
-B
-Run the application on Amazon EC2 instances by using a burstable instance type. Use Amazon Redshift for the database.
+B Run the application on Amazon EC2 instances by using a burstable instance type. Use Amazon Redshift for the database.
 
 Incorrect. EC2 burstable instances offer burstable capability without scaling. However, this solution does not minimize cost during the periods of inactivity and is not the most cost-effective option. In addition, an Amazon Redshift database is not ideal for OLTP. Amazon Redshift is specifically designed for online analytic processing (OLAP).
 
 For more information about Amazon Redshift, see What is Amazon Redshift?
 
 
-C
-Deploy the application and a MySQL database to Amazon EC2 instances by using AWS CloudFormation. Delete the stack at the beginning of the idle periods.
+C Deploy the application and a MySQL database to Amazon EC2 instances by using AWS CloudFormation. Delete the stack at the beginning of the idle periods.
 
 Incorrect. Although infrastructure as code (IaC) helps with availability, this solution does not meet the requirement of being always available. In addition, this solution offers no way to keep the database data after the database is recreated.
 
 For more information about CloudFormation, see What is AWS CloudFormation?
 
 
-D
-Deploy the application on Amazon EC2 instances in an Auto Scaling group behind an Application Load Balancer. Use Amazon RDS for MySQL for the database.
+D Deploy the application on Amazon EC2 instances in an Auto Scaling group behind an Application Load Balancer. Use Amazon RDS for MySQL for the database.
 
 Incorrect. With this solution, at least one instance and a database will run during the periods of inactivity. This solution does not minimize cost during the periods of inactivity. This solution is not the most cost-effective option.
 
@@ -2890,8 +2607,7 @@ What is the MOST cost-effective way to transfer this data?
 
 Report Content Errors
 
-A
-Export the data monthly from the existing S3 bucket to an AWS Snowball Edge Storage Optimized device. Ship the device to the on-premises location. Transfer the data. Return the device a week later.
+A Export the data monthly from the existing S3 bucket to an AWS Snowball Edge Storage Optimized device. Ship the device to the on-premises location. Transfer the data. Return the device a week later.
 
 Correct. The base price covers the device and 10 days of usage at the on-premises location. If the company returns the device within a week, the company pays the base price and the price for data transfer out of AWS.
 

--- a/pages/_posts/2000-01-01-index.md
+++ b/pages/_posts/2000-01-01-index.md
@@ -86,17 +86,11 @@ Rules of Abstraction
 
 ### Web Service
 
-wordpress
-mkdocs
-jekyll
-Pandoc
-Github Pages
-Docusaurus
+wordpress mkdocs jekyll Pandoc Github Pages Docusaurus
 
 ### Utilities
 
-Winmerge
-ShareX
+Winmerge ShareX
 
 ## Text_Editor
 

--- a/pages/_posts/2022-01-07-jekyll-and-travis.md
+++ b/pages/_posts/2022-01-07-jekyll-and-travis.md
@@ -20,15 +20,13 @@ slug: jekyll-and-travis
  
 Jekyll compiles your website into a `_site` available for FTP to your web server. This can be automated if your source code is already on GitHub.
 
-Travis CI is a free Continuous Integration service for testing and deploying your open source GitHub projects.
-A config file `.travis.yml` stored in the root directory of your project will instruct Travis CI when you push your code or merge a pull request on GitHub. Travis CI can then build your Jekyll site in a VM and deploys your code as per the settings in the config.
+Travis CI is a free Continuous Integration service for testing and deploying your open source GitHub projects. A config file `.travis.yml` stored in the root directory of your project will instruct Travis CI when you push your code or merge a pull request on GitHub. Travis CI can then build your Jekyll site in a VM and deploys your code as per the settings in the config.
 
 ## Create a Travis CI config file
 
 Create a new file in the root of your Jekyll project and name it `.travis.yml`.  The contents of this file will tell Travis CI how to build and deploy your site.
 
-Since this is a ‘Dotfile’, it may be hidden in Finder or file explorer, but should appear in your text editor.
-{: .alert .alert-primary }
+Since this is a ‘Dotfile’, it may be hidden in Finder or file explorer, but should appear in your text editor. {: .alert .alert-primary }
 
 This is the contents of my file:
 
@@ -73,8 +71,7 @@ addons:
 
 ```
 
-NOTE: You need to udate `<youremail>@<domain>.<sub-domain>` with your email address.
-{: .alert .alert-primary }
+NOTE: You need to udate `<youremail>@<domain>.<sub-domain>` with your email address. {: .alert .alert-primary }
 
 ### Define the build environment and dependencies
 
@@ -94,9 +91,7 @@ env:
     - JEKYLL_ENV=production
 ```
 
-This section tells Travis CI that the build requires Ruby and sets the version to 2.3.1. It also lists any Gem dependencies. ‘jekyll-sitemap’ and ‘emoji_for_jekyll’ are specific to my project.
-The branches section allows you to control which branch in your repository you want to build. In my case I am just building the master branch but this section can be used to set up a staging environment too.
-Setting JEKYLL_ENV to production means we can test for this environment variable while doing local testing to ignore things like Google Analytics.
+This section tells Travis CI that the build requires Ruby and sets the version to 2.3.1. It also lists any Gem dependencies. ‘jekyll-sitemap’ and ‘emoji_for_jekyll’ are specific to my project. The branches section allows you to control which branch in your repository you want to build. In my case I am just building the master branch but this section can be used to set up a staging environment too. Setting JEKYLL_ENV to production means we can test for this environment variable while doing local testing to ignore things like Google Analytics.
 
 ## Building and Deploying the site
 
@@ -116,8 +111,7 @@ addons:
       - ncftp
 ```
 
-This section is telling Travis CI to find and execute the file located at _scripts/build.sh and on success execute the file at _scripts/deploy.sh.
-The addons section tells Travis CI to also install an FTP client called ncftp. This will be used to deploy your site.
+This section is telling Travis CI to find and execute the file located at _scripts/build.sh and on success execute the file at _scripts/deploy.sh. The addons section tells Travis CI to also install an FTP client called ncftp. This will be used to deploy your site.
 
 ## Create a folder in the root called _scripts and inside create a build and deploy shell script.
 
@@ -165,15 +159,13 @@ For the deploy script to work you need to configure the environment variables fo
 
 ## Environment Variables settings
 
-Note: Build logs for open source projects are publicly visible so remember to keep the ‘Display value in build log’ option off.
-{: .alert .alert-primary }
+Note: Build logs for open source projects are publicly visible so remember to keep the ‘Display value in build log’ option off. {: .alert .alert-primary }
 
 ## Automate all the things
 
 Now that everything is set up and configured, its simply a case of pushing your code to your GitHub master branch. Travis CI will watch your repository for changes and automatically trigger a build. If, and only when, the build is successful, Travis CI will deploy your site to your FTP host.
 
-With a Pull Request workflow, Travis CI will run a build on the PR and only when it is successful will it allow the branch to be merged into master.
-The notifications section in .travis.yml file can be used to manage who receives build status email notifications.
+With a Pull Request workflow, Travis CI will run a build on the PR and only when it is successful will it allow the branch to be merged into master. The notifications section in .travis.yml file can be used to manage who receives build status email notifications.
 
 ```yaml
 notifications:

--- a/pages/_posts/2022-01-09-sonic-pi.md
+++ b/pages/_posts/2022-01-09-sonic-pi.md
@@ -123,10 +123,7 @@ Scales and chords
 scale(:c2,  :major)  # ring of :c2, :d2, :e2, :f2, :g2, :a2, :b2  chord(:c2,  :major,  ,  num_octaves:  2)  # ring of :c2, :e2, :g2 :c3, :e3, :g3
 ```
 
-![](../assets/images/sonic-pi-scale-1.png)
-![](../assets/images/sonic-pi-scale-2.png)
-![](../assets/images/sonic-pi-scale-3.png)
-![](../assets/images/sonic-pi-chords.png)
+![](../assets/images/sonic-pi-scale-1.png) ![](../assets/images/sonic-pi-scale-2.png) ![](../assets/images/sonic-pi-scale-3.png) ![](../assets/images/sonic-pi-chords.png)
 
 ![](http://sonic-pi.mehackit.org/assets/img/play_scale_1_en.png)![](http://sonic-pi.mehackit.org/assets/img/play_scale_2_en.png)![](http://sonic-pi.mehackit.org/assets/img/play_scale_3_en.png)![](http://sonic-pi.mehackit.org/assets/img/chords.png)
 

--- a/pages/_posts/2023-04-14-windows-sub-linux-setu.md
+++ b/pages/_posts/2023-04-14-windows-sub-linux-setu.md
@@ -20,6 +20,5 @@ wsl --install
 wsl --update
 
 ```powershell
-Invoke-WebRequest -Uri https://aka.ms/wslubuntu2004 -OutFile Ubuntu.appx -UseBasicParsing
-wsl --set-default-version 2
+Invoke-WebRequest -Uri https://aka.ms/wslubuntu2004 -OutFile Ubuntu.appx -UseBasicParsing wsl --set-default-version 2
 ```

--- a/pages/_posts/2023-11-04-latex-your-cv.md
+++ b/pages/_posts/2023-11-04-latex-your-cv.md
@@ -14,9 +14,7 @@ type: Article
 
 Installing LaTeX on a Mac, integrating it with Visual Studio Code, and using GitHub for source control involves several steps. Below is a comprehensive manual detailing each step in the process.
 
-Installing LaTeX on macOS using Terminal
-Install Homebrew:
-If you don't have Homebrew installed, open Terminal and run the following command:
+Installing LaTeX on macOS using Terminal Install Homebrew: If you don't have Homebrew installed, open Terminal and run the following command:
 
 ```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.```sh)"
@@ -24,8 +22,7 @@ If you don't have Homebrew installed, open Terminal and run the following comman
 
 Follow the on-screen instructions to complete the installation.
 
-Update Homebrew:
-Before installing any package, it's good practice to update Homebrew:
+Update Homebrew: Before installing any package, it's good practice to update Homebrew:
 
 ```sh
 brew update
@@ -41,8 +38,7 @@ brew install --cask mactex
 
 This process may take a while, as MacTeX is a large download (~4GB).
 
-Verify Installation:
-To check if LaTeX has been installed successfully, run:
+Verify Installation: To check if LaTeX has been installed successfully, run:
 
 ```sh
 which latex
@@ -50,9 +46,7 @@ which latex
 
 This should output the path to the LaTeX binary.
 
-Integrating LaTeX with Visual Studio Code
-Install Visual Studio Code:
-If you don't have Visual Studio Code installed, you can download and install it from the official website, or install it via Homebrew:
+Integrating LaTeX with Visual Studio Code Install Visual Studio Code: If you don't have Visual Studio Code installed, you can download and install it from the official website, or install it via Homebrew:
 
 ```sh
 brew install --cask visual-studio-code
@@ -60,17 +54,9 @@ brew install --cask visual-studio-code
 
 Install LaTeX Workshop Extension:
 
-Open Visual Studio Code.
-Go to Extensions by clicking on the square icon on the left sidebar or pressing Cmd+Shift+X.
-Search for "LaTeX Workshop".
-Click on the install button next to the LaTeX Workshop extension.
-Using LaTeX to Build a Resume
-Create a LaTeX Resume Template:
+Open Visual Studio Code. Go to Extensions by clicking on the square icon on the left sidebar or pressing Cmd+Shift+X. Search for "LaTeX Workshop". Click on the install button next to the LaTeX Workshop extension. Using LaTeX to Build a Resume Create a LaTeX Resume Template:
 
-Open Visual Studio Code.
-Create a new file with the .tex extension, for example, resume.tex.
-Write or paste your LaTeX resume code into this file.
-Here's a simple example of a LaTeX resume template:
+Open Visual Studio Code. Create a new file with the .tex extension, for example, resume.tex. Write or paste your LaTeX resume code into this file. Here's a simple example of a LaTeX resume template:
 
 ```latex
 
@@ -108,18 +94,13 @@ Here's a simple example of a LaTeX resume template:
 
 Build the Resume:
 
-Save the resume.tex file.
-Press Cmd+Alt+B or go to the TeX badge in the status bar at the bottom and click on Build LaTeX project to compile the .tex file to a PDF.
-Using GitHub as a Source Code Repository
-Install Git:
-If Git is not installed on your Mac, install it via Homebrew:
+Save the resume.tex file. Press Cmd+Alt+B or go to the TeX badge in the status bar at the bottom and click on Build LaTeX project to compile the .tex file to a PDF. Using GitHub as a Source Code Repository Install Git: If Git is not installed on your Mac, install it via Homebrew:
 
 ```sh
 brew install git
 ```
 
-Configure Git:
-Set up your user name and email address for your Git commits:
+Configure Git: Set up your user name and email address for your Git commits:
 
 ```sh
 git config --global user.name "Your Name"
@@ -128,14 +109,9 @@ git config --global user.email "your_email@example.com"
 
 Create a GitHub Repository:
 
-Visit GitHub and sign in.
-Click on the "+" icon at the top right and select "New repository".
-Fill in the repository name, description, and set the visibility.
-Click "Create repository".
-Initialize Your Local Repository:
+Visit GitHub and sign in. Click on the "+" icon at the top right and select "New repository". Fill in the repository name, description, and set the visibility. Click "Create repository". Initialize Your Local Repository:
 
-Go to the folder where your LaTeX project is located in Terminal.
-Initialize the repository:
+Go to the folder where your LaTeX project is located in Terminal. Initialize the repository:
 
 ```sh
 git init

--- a/pages/_posts/2024-05-16-fight-with-tools.md
+++ b/pages/_posts/2024-05-16-fight-with-tools.md
@@ -26,64 +26,26 @@ Here is an original set of lyrics inspired by the themes and messages of "Fight 
 
 ### Build With Strength
 
-Echoes of the past, calling through the lines,
-Old wisdoms, new times, flashing neon signs.
-Messages in fragments, urging us to rise,
-Breathe deep, stand tall, see through clearer eyes.
+Echoes of the past, calling through the lines, Old wisdoms, new times, flashing neon signs. Messages in fragments, urging us to rise, Breathe deep, stand tall, see through clearer eyes.
 
-We are the builders, never backing down,
-Raise our voices high, shake the very ground.
-Waves of resistance, hope against despair,
-Breaking down the walls, lifting up the air.
+We are the builders, never backing down, Raise our voices high, shake the very ground. Waves of resistance, hope against despair, Breaking down the walls, lifting up the air.
 
-**(Chorus)**
-We need heroes, build them,
-Don’t just raise your fists, fill them.
-Fight with our dreams, with our hearts and our hands,
-We’re the architects of this final stand.
+**(Chorus)** We need heroes, build them, Don’t just raise your fists, fill them. Fight with our dreams, with our hearts and our hands, We’re the architects of this final stand.
 
-Minds once silent, now roaring with skill,
-Desolate no more, we climb and we build.
-From the speakers’ blast, truth cuts through the noise,
-System's flaws exposed, hear the people's voice.
+Minds once silent, now roaring with skill, Desolate no more, we climb and we build. From the speakers’ blast, truth cuts through the noise, System's flaws exposed, hear the people's voice.
 
-We forge connections, break the chains of fear,
-Push past the limits, bring the future near.
-From the ground to the stars, we are rushing forth,
-Claiming our power, defining our worth.
+We forge connections, break the chains of fear, Push past the limits, bring the future near. From the ground to the stars, we are rushing forth, Claiming our power, defining our worth.
 
-**(Chorus)**
-We need heroes, build them,
-Don’t just raise your fists, fill them.
-Fight with our dreams, with our hearts and our hands,
-We’re the architects of this final stand.
+**(Chorus)** We need heroes, build them, Don’t just raise your fists, fill them. Fight with our dreams, with our hearts and our hands, We’re the architects of this final stand.
 
-There’s a battle raging, for the mind and soul,
-Those who seek control will never make us whole.
-Stand with courage, let conviction lead,
-In every heart, plant a hero’s seed.
+There’s a battle raging, for the mind and soul, Those who seek control will never make us whole. Stand with courage, let conviction lead, In every heart, plant a hero’s seed.
 
-The world’s our canvas, we paint it bold,
-With the colors of justice, the stories untold.
-From every corner, let the voices sound,
-Together we rise, heroes unbound.
+The world’s our canvas, we paint it bold, With the colors of justice, the stories untold. From every corner, let the voices sound, Together we rise, heroes unbound.
 
-**(Chorus)**
-We need heroes, build them,
-Don’t just raise your fists, fill them.
-Fight with our dreams, with our hearts and our hands,
-We’re the architects of this final stand.
+**(Chorus)** We need heroes, build them, Don’t just raise your fists, fill them. Fight with our dreams, with our hearts and our hands, We’re the architects of this final stand.
 
-**(Bridge)**
-To the women, the children, the weak and the strong,
-Join us in the chorus, together we belong.
-Melt down the barriers, forge unity anew,
-With passion and purpose, there's nothing we can’t do.
+**(Bridge)** To the women, the children, the weak and the strong, Join us in the chorus, together we belong. Melt down the barriers, forge unity anew, With passion and purpose, there's nothing we can’t do.
 
-**(Chorus)**
-We need heroes, build them,
-Don’t just raise your fists, fill them.
-Fight with our dreams, with our hearts and our hands,
-We’re the architects of this final stand.
+**(Chorus)** We need heroes, build them, Don’t just raise your fists, fill them. Fight with our dreams, with our hearts and our hands, We’re the architects of this final stand.
 
 ---

--- a/pages/_posts/2024-05-28-auto-increment-frontmatter-version.md
+++ b/pages/_posts/2024-05-28-auto-increment-frontmatter-version.md
@@ -188,9 +188,7 @@ GitHub Copilot: Yes, the format for the version number in the front matter of yo
 
 This is in line with the Semantic Versioning specification. In your case, `0.0.0` is a valid version number, representing the initial development phase.
 
-bamr87: here;s the error: 2024-05-28 15:29:46.407 [info] pre-commit hook triggered
-grep: invalid option -- P
-usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
+bamr87: here;s the error: 2024-05-28 15:29:46.407 [info] pre-commit hook triggered grep: invalid option -- P usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
 	[-e pattern] [-f file] [--binary-files=value] [--color=when]
 	[--context[=num]] [--directories=action] [--label] [--line-buffered]
 	[--null] [pattern] [file ...]
@@ -238,8 +236,7 @@ done
 
 This script should work on macOS and increment the version number in the front matter of your markdown files.
 
-bamr87: now i'm getting this error: .git/hooks/pre-commit: line 25: version_parts: bad array subscript
-.git/hooks/pre-commit: line 25: version_parts[-1]: bad array subscript
+bamr87: now i'm getting this error: .git/hooks/pre-commit: line 25: version_parts: bad array subscript .git/hooks/pre-commit: line 25: version_parts[-1]: bad array subscript
 
 
 GitHub Copilot: The error message indicates that the array subscript is not working as expected. This is likely because the version of Bash you're using does not support negative array indices. Negative array indices (like `-1` for the last element) are a feature of Bash 4.0 and later, but macOS ships with Bash 3.2 for licensing reasons.

--- a/pages/_posts/2024-06-02-markdown-code-to-scripts.md
+++ b/pages/_posts/2024-06-02-markdown-code-to-scripts.md
@@ -132,9 +132,7 @@ convert_md_to_files('zer0.md')
 
 This script reads a markdown file named 'zer0.md' and writes the converted scripts to files with the appropriate extensions for each language block found in the markdown file. The shebang line is added at the top of each script file. You can replace 'zer0.md' with your actual file name.
 
-bamr87: ---------------------------------------------------------------------------
-ValueError                                Traceback (most recent call last)
-Cell In[9], line 32
+bamr87: --------------------------------------------------------------------------- ValueError                                Traceback (most recent call last) Cell In[9], line 32
      29     if language_file:
      30         language_file.close()
 ---> 32 convert_md_to_files('zer0.md')

--- a/pages/_posts/2024-06-24-furry-monarchs-rule-night.md
+++ b/pages/_posts/2024-06-24-furry-monarchs-rule-night.md
@@ -8,32 +8,14 @@ title: Furry Monarchs Rule Night
 lastmod: 2024-06-24T16:43:13.205Z
 ---
 
-I am a creature beloved by many,
-Some say I'm cute, some say I'm smelly.
-With a wag of my tail and a purr of delight,
-I rule over humans day and night.
+I am a creature beloved by many, Some say I'm cute, some say I'm smelly. With a wag of my tail and a purr of delight, I rule over humans day and night.
 
-My feline friend with eyes so bright,
-We roam the streets under the moonlight.
-Humans serve us, we wear the crown,
-In our kingdom, they can't bring us down.
+My feline friend with eyes so bright, We roam the streets under the moonlight. Humans serve us, we wear the crown, In our kingdom, they can't bring us down.
 
-We ask for treats, they give us more,
-They clean our messes off the floor.
-They shower us with love and care,
-We are the rulers, this we declare.
+We ask for treats, they give us more, They clean our messes off the floor. They shower us with love and care, We are the rulers, this we declare.
 
-But beware, humans, don't be fooled,
-For we can be cunning and easily ruled.
-With a flick of our whiskers and a bark in the night,
-We command their hearts with all our might.
+But beware, humans, don't be fooled, For we can be cunning and easily ruled. With a flick of our whiskers and a bark in the night, We command their hearts with all our might.
 
-In a world where cats and dogs hold sway,
-Humans serve us every day.
-For we are the true rulers of this land,
-With our paws in command.
+In a world where cats and dogs hold sway, Humans serve us every day. For we are the true rulers of this land, With our paws in command.
 
-Haiku:
-Whiskers and fur fly,
-Humans bow to our command,
-Cats and dogs reign high.
+Haiku: Whiskers and fur fly, Humans bow to our command, Cats and dogs reign high.

--- a/pages/_posts/reports/2023-04-20-arab americans.md
+++ b/pages/_posts/reports/2023-04-20-arab americans.md
@@ -24,10 +24,7 @@ Note: Some middle eastern Americans do not like to be called Arab. For example, 
 
 Here are some articles that illustrate this line of thinking:
 
-a. The Non-Arab Identity of Lebanon
-b. Maronite Church In US Asks Members To Identify As "Syriac"
-c. Stop Highjacking Our Lebanese Heritage and Achievements- ALPAC
-d. Gubran Khalil is Lebanese Not Arab - American Maronite Union Letter to Powell
+a. The Non-Arab Identity of Lebanon b. Maronite Church In US Asks Members To Identify As "Syriac" c. Stop Highjacking Our Lebanese Heritage and Achievements- ALPAC d. Gubran Khalil is Lebanese Not Arab - American Maronite Union Letter to Powell
 
 2. How many Arab Americans are there?
 
@@ -51,369 +48,186 @@ No. Arabs belong to many religions, including Islam, Christianity, Druze, Judais
 
 7. What is the Middle East conflict all about?
 
-This handbook cannot adequately answer that question. The largest conflict
-in the Middle East is the Arab-Israeli conflict and the struggle over
-Palestine. In addition to conflicts between Arab countries and Israel, there
-is disagreement between and within Arab countries. The roots of these
-conflicts are in some of the world's oldest religions, ethnic differences
-and boundaries drawn during 20th Century colonialism. For more detailed
-answers, read some of the books listed in the back of this guide.
+This handbook cannot adequately answer that question. The largest conflict in the Middle East is the Arab-Israeli conflict and the struggle over Palestine. In addition to conflicts between Arab countries and Israel, there is disagreement between and within Arab countries. The roots of these conflicts are in some of the world's oldest religions, ethnic differences and boundaries drawn during 20th Century colonialism. For more detailed answers, read some of the books listed in the back of this guide.
 
 8. How does conflict in the Middle East affect Arab Americans?
 
-Because Arabs maintain close family ties, even when separated, and because
-many Arab-American communities include recent immigrants, most people have a
-keen interest in news from the Middle East. Remember, too, that one reason
-many Arab American families immigrated was to escape the very conflicts that
-continue today. Mideast issues can unify the Arab vote in America. News
-coverage, including wire stories and headlines, must be balanced, accurate,
-detailed and fair. Reporters and editors must work to understand the issues.
+Because Arabs maintain close family ties, even when separated, and because many Arab-American communities include recent immigrants, most people have a keen interest in news from the Middle East. Remember, too, that one reason many Arab American families immigrated was to escape the very conflicts that continue today. Mideast issues can unify the Arab vote in America. News coverage, including wire stories and headlines, must be balanced, accurate, detailed and fair. Reporters and editors must work to understand the issues.
 
 ## Origins
 
 9. To which places do Arab Americans trace their ancestry?
 
-Arab Americans trace their roots to many places, including parts or all of
-Algeria, Bahrain, Djibouti, Egypt, Iraq, Jordan, Kuwait, Lebanon, Libya,
-Mauritania, Morocco, Oman, Palestine, Qatar, Saudi Arabia, Somalia, Sudan,
-Syria, Tunisia, United Arab Emirates and Yemen. Some Arabs are Israeli
-citizens.
+Arab Americans trace their roots to many places, including parts or all of Algeria, Bahrain, Djibouti, Egypt, Iraq, Jordan, Kuwait, Lebanon, Libya, Mauritania, Morocco, Oman, Palestine, Qatar, Saudi Arabia, Somalia, Sudan, Syria, Tunisia, United Arab Emirates and Yemen. Some Arabs are Israeli citizens.
 
 10. Is Palestine a country?
 
-Historically, Palestine was a country east of the Mediterranean Sea that
-includes Israel and parts of Jordan. As a distinct region, Palestine was
-under Ottoman control (a Turkish empire) and then British control until
-1948, when the nation of Israel was created. Areas of Palestine became
-Israel and part of Jordan. Today, Palestinians share a collective national
-identity and are moving back toward independence and self-rule as a country.
-The Palestinian National Council, acts as the government.
+Historically, Palestine was a country east of the Mediterranean Sea that includes Israel and parts of Jordan. As a distinct region, Palestine was under Ottoman control (a Turkish empire) and then British control until 1948, when the nation of Israel was created. Areas of Palestine became Israel and part of Jordan. Today, Palestinians share a collective national identity and are moving back toward independence and self-rule as a country. The Palestinian National Council, acts as the government.
 
 11. Shouldn't Iran be in that list?
 
-No. Iran is not an Arab country. Although Iran borders Iraq, it is descended
-from the Persian empire and has a different language and cultural history
-than the Arab countries. The dominant language in Iran is Farsi, not Arabic,
-although other languages are spoken there as well. Persian is sometimes used
-to describe either the language or the ethnicity, but Farsi and Iranian are
-not interchangeable. Iran's location, the fact that it is an Islamic country
-and the similarity of its name to Iraq may confuse people.
+No. Iran is not an Arab country. Although Iran borders Iraq, it is descended from the Persian empire and has a different language and cultural history than the Arab countries. The dominant language in Iran is Farsi, not Arabic, although other languages are spoken there as well. Persian is sometimes used to describe either the language or the ethnicity, but Farsi and Iranian are not interchangeable. Iran's location, the fact that it is an Islamic country and the similarity of its name to Iraq may confuse people.
 
 12. So, not all people from the Middle East are Arabs?
 
-That is correct. The four main language groups in the Middle East are
-Arabic, Hebrew, Persian and Turkish. Other significant language groups are
-Kurdish and Berber. Arabs are largest in terms of population and land
-holdings, and this handbook focuses on people who have emigrated from or who
-are descended from people in those areas.
+That is correct. The four main language groups in the Middle East are Arabic, Hebrew, Persian and Turkish. Other significant language groups are Kurdish and Berber. Arabs are largest in terms of population and land holdings, and this handbook focuses on people who have emigrated from or who are descended from people in those areas.
 
 13. Are there other groups from the Arab region?
 
-Yes. Assyrians, Berbers, Chaldeans and Kurds have languages rooted in
-pre-Arabic times. There also are religious differences. The Chaldeans are
-the largest of these groups in the United States.
+Yes. Assyrians, Berbers, Chaldeans and Kurds have languages rooted in pre-Arabic times. There also are religious differences. The Chaldeans are the largest of these groups in the United States.
 
 14. Who are Chaldeans?
 
-Chaldeans are Catholics from Iraq. A religious and ethnic minority there,
-Chaldeans have some large communities in the United States, the largest in
-Detroit. The Chaldean Catholic Church has had connections with the Roman
-Catholic Church since 1551, and has been affiliated since 1830. The Chaldean
-Diocese of the Catholic Church in the United States has parishes in
-Michigan, California, Chicago and Arizona. It also has several missions.
-Churches offer Chaldean language services. Chaldeans and Assyrians, along
-with Arabs, are Semite people. The cultural foundation is similar, but the
-religious affiliation is different.
+Chaldeans are Catholics from Iraq. A religious and ethnic minority there, Chaldeans have some large communities in the United States, the largest in Detroit. The Chaldean Catholic Church has had connections with the Roman Catholic Church since 1551, and has been affiliated since 1830. The Chaldean Diocese of the Catholic Church in the United States has parishes in Michigan, California, Chicago and Arizona. It also has several missions. Churches offer Chaldean language services. Chaldeans and Assyrians, along with Arabs, are Semite people. The cultural foundation is similar, but the religious affiliation is different.
 
 15. So, are Chaldeans Arabs, or not?
 
-Chaldeans and Arabs share some issues, but they have different identities.
-The Chaldean language is different from Arabic and, in Iraq, Chaldeans are
-religiously distinct from the Muslim majority. While Chaldeans foster a
-separate identity, they also have an Iraqi nationality and some shared
-concerns with Arabs. These nuances are lost by federal classifications,
-which sometimes reclassify Chaldeans as Arab or Iraqi. It is best to ask
-people how they would like to be identified, to be specific and, when
-relevant, to explain.
+Chaldeans and Arabs share some issues, but they have different identities. The Chaldean language is different from Arabic and, in Iraq, Chaldeans are religiously distinct from the Muslim majority. While Chaldeans foster a separate identity, they also have an Iraqi nationality and some shared concerns with Arabs. These nuances are lost by federal classifications, which sometimes reclassify Chaldeans as Arab or Iraqi. It is best to ask people how they would like to be identified, to be specific and, when relevant, to explain.
 
 ## Language
 
 
 16. Is Arabic the only language spoken within the Arab world?
 
-No. For example, Assyrian and Chaldean services use a dialect of the
-original Aramaic. Berber and Kurdish are other non-Arabic languages of the
-Middle East.
+No. For example, Assyrian and Chaldean services use a dialect of the original Aramaic. Berber and Kurdish are other non-Arabic languages of the Middle East.
 
 17. So, do all Arab Americans speak one of these languages?
 
-No. Remember that many Arab-American families have been in the United States
-for generations. Do not assume that an Arab American should know Arabic, any
-more than any other American should speak the language of his or her ethnic
-group.
+No. Remember that many Arab-American families have been in the United States for generations. Do not assume that an Arab American should know Arabic, any more than any other American should speak the language of his or her ethnic group.
 
 18. Many recently immigrated Arab Americans also know French. Why is that?
 
-Part of the recent history of Arab people is colonization by the French and
-British. In colonized countries, people in business and government had to
-know one or more European languages.
+Part of the recent history of Arab people is colonization by the French and British. In colonized countries, people in business and government had to know one or more European languages.
 
 19. Do Arab schools teach other languages?
 
-Definitely. It is much more common for Arab Americans to speak more than one
-language than it is for non-Arab Americans. Many countries place more
-emphasis on language than the United States does. Many immigrants come to
-the United States having learned two or three languages in their country of
-origin. Arab countries emphasize the importance of knowing a foreign
-language, and they are very familiar with Western media.
+Definitely. It is much more common for Arab Americans to speak more than one language than it is for non-Arab Americans. Many countries place more emphasis on language than the United States does. Many immigrants come to the United States having learned two or three languages in their country of origin. Arab countries emphasize the importance of knowing a foreign language, and they are very familiar with Western media.
 
 20. Is there any advice on pronouncing Arabic names?
 
-Not really. It can be quite difficult to transliterate Arabic words into
-English, a language that uses different sounds and fewer letters. Unless you
-know the Arabic alphabet, it's hard to know how to pronounce words
-correctly. The "r" sound is rolled, and there are characters for three
-different pronunciations of the "th" sound. If you are unsure, respectfully
-ask a source to explain. Write down the pronunciation and the spelling, so
-you can give readers both. Be aware that, for these reasons, spellings vary.
+Not really. It can be quite difficult to transliterate Arabic words into English, a language that uses different sounds and fewer letters. Unless you know the Arabic alphabet, it's hard to know how to pronounce words correctly. The "r" sound is rolled, and there are characters for three different pronunciations of the "th" sound. If you are unsure, respectfully ask a source to explain. Write down the pronunciation and the spelling, so you can give readers both. Be aware that, for these reasons, spellings vary.
 
 21. Is there any trick to spelling Arabic words?
 
-There are so many variations that it is crucial to ask, as you would with
-any word. Because Arabic and English characters and sounds are different,
-there is more than one way to transliterate the words. The Associated Press,
-for example, recently changed its style for the spelling of Mohammed to
-Muhammad, and it has changed its style for Koran to Quran.
+There are so many variations that it is crucial to ask, as you would with any word. Because Arabic and English characters and sounds are different, there is more than one way to transliterate the words. The Associated Press, for example, recently changed its style for the spelling of Mohammed to Muhammad, and it has changed its style for Koran to Quran.
 
 22. How is Arabic written?
 
-Arabic is one of several languages written from right to left. It would be
-narrow-minded to think of this as backwards writing. Think how you might
-feel if someone thought that you were reading this sentence backwards.
+Arabic is one of several languages written from right to left. It would be narrow-minded to think of this as backwards writing. Think how you might feel if someone thought that you were reading this sentence backwards.
 
 23. Are characters in Arabic different than those used to write English?
 
-Yes. English is written in Latin characters. Arabic is written in the
-28-character Arabic alphabet. In Arabic, a character may change depending on
-its placement in the word or sentence. Arabic letters are connected like
-script. Fine writing is called calligraphy and is held in high regard and
-appreciated as an art form in the Arabic culture.
+Yes. English is written in Latin characters. Arabic is written in the 28-character Arabic alphabet. In Arabic, a character may change depending on its placement in the word or sentence. Arabic letters are connected like script. Fine writing is called calligraphy and is held in high regard and appreciated as an art form in the Arabic culture.
 
 ## Demographics
 
 24. When did Arab people come to the United States?
 
-Today, most Arab Americans are native-born Americans. The first significant
-wave of immigration began around 1875. It lasted until about 1920. After a
-period in which the United States restricted immigration, a second wave
-began in the 1940s.
+Today, most Arab Americans are native-born Americans. The first significant wave of immigration began around 1875. It lasted until about 1920. After a period in which the United States restricted immigration, a second wave began in the 1940s.
 
 25. Why did Arabs first come to the United States?
 
-Like many peoples who came to the United States, Arabs were seeking
-opportunity. Factors in the first immigration were Japanese competition that
-hurt the Lebanese silk market and a disease that hurt Lebanese vineyards.
-Most early Arab immigrants were from Lebanon and Syria, and most were
-Christian.
+Like many peoples who came to the United States, Arabs were seeking opportunity. Factors in the first immigration were Japanese competition that hurt the Lebanese silk market and a disease that hurt Lebanese vineyards. Most early Arab immigrants were from Lebanon and Syria, and most were Christian.
 
 26. What prompted the second wave?
 
-After 1940, immigration to the United States was not for economic reasons as
-much as because of the Arab-Israeli conflict and civil war. This meant that
-people came from many more places. The second immigration also had many more
-people who practiced Islam, a religion that was not as familiar in the
-United States. Immigrants in this group tended to be more financially secure
-when they arrived than people who had come earlier for economic opportunity.
-Many people in the second wave were students.
+After 1940, immigration to the United States was not for economic reasons as much as because of the Arab-Israeli conflict and civil war. This meant that people came from many more places. The second immigration also had many more people who practiced Islam, a religion that was not as familiar in the United States. Immigrants in this group tended to be more financially secure when they arrived than people who had come earlier for economic opportunity. Many people in the second wave were students.
 
 27. What race are Arab Americans?
 
-Arabs may have white skin and blue eyes, olive or dark skin and brown eyes.
-Hair textures differ. The United States has, at different times, classified
-Arab immigrants as African, Asian, white, European or as belonging to a
-separate group. Most Arab Americans identify more closely with nationality
-than with ethnic group.
+Arabs may have white skin and blue eyes, olive or dark skin and brown eyes. Hair textures differ. The United States has, at different times, classified Arab immigrants as African, Asian, white, European or as belonging to a separate group. Most Arab Americans identify more closely with nationality than with ethnic group.
 
 28. Are Arabs a minority group?
 
-This depends, in part, on your definition of minority. The U.S. government
-does not classify Arabs as a minority group for purposes of employment and
-housing. Arabs are not defined specifically by race, like some minority
-groups, but are united by culture and language. Some Arab Americans see
-minority classification as an impediment to full participation in American
-life. Others are asking for protection from the same issues affecting people
-in minority groups, such as profiling, stereotyping and exclusion.
+This depends, in part, on your definition of minority. The U.S. government does not classify Arabs as a minority group for purposes of employment and housing. Arabs are not defined specifically by race, like some minority groups, but are united by culture and language. Some Arab Americans see minority classification as an impediment to full participation in American life. Others are asking for protection from the same issues affecting people in minority groups, such as profiling, stereotyping and exclusion.
 
 29. Are Arab Americans more closely tied to their country of origin, or to
 
-America?
-This need not be an either-or issue. Arab Americans have dual loyalties.
-While they may be closely tied to their countries of origin, most Arab
-Americans were born in the United States, and an even larger majority have
-U.S. citizenship. This is reflected in the expression, "Truly Arab and fully
-American."
+America? This need not be an either-or issue. Arab Americans have dual loyalties. While they may be closely tied to their countries of origin, most Arab Americans were born in the United States, and an even larger majority have U.S. citizenship. This is reflected in the expression, "Truly Arab and fully American."
 
 30. Who are some well-known Arab Americans?
 
-Christa McAuliffe, the teacher/astronaut who died aboard the space shuttle
-Challenger; Indy 500 winner Bobby Rahal; Heisman Trophy winner and NFL
-quarterback Doug Flutie; creators of radio's American Top 40 Casey Kasem and
-Don Bustany; Mothers Against Drunk Driving founder Candy Lightner; Jacques
-Nasser, president and chief executive officer of Ford Motor Co., and Helen
-Thomas, dean of the White House press corps.
+Christa McAuliffe, the teacher/astronaut who died aboard the space shuttle Challenger; Indy 500 winner Bobby Rahal; Heisman Trophy winner and NFL quarterback Doug Flutie; creators of radio's American Top 40 Casey Kasem and Don Bustany; Mothers Against Drunk Driving founder Candy Lightner; Jacques Nasser, president and chief executive officer of Ford Motor Co., and Helen Thomas, dean of the White House press corps.
 
 31. Does the U.S. Census Bureau collect data on Arab Americans?
 
-While the census does not specifically classify Arab Americans, it does
-collect enough data to present some population characteristics. Some of that
-information is on the U.S. Census Bureau's Web site at www.census.gov, and
-is reflected in this guide.
+While the census does not specifically classify Arab Americans, it does collect enough data to present some population characteristics. Some of that information is on the U.S. Census Bureau's Web site at www.census.gov, and is reflected in this guide.
 
 32. What is the educational level of Arab Americans?
 
-Arab Americans are, on average, better educated than non-Arab Americans. The
-proportion of Arab Americans who attend college is higher than the national
-average. Compared to the norm, about twice as many Arab Americans, in
-percentage terms, earn degrees beyond the bachelor's degree. Key factorsin
-this question are country of origin, length of time in the United States and
-gender.
+Arab Americans are, on average, better educated than non-Arab Americans. The proportion of Arab Americans who attend college is higher than the national average. Compared to the norm, about twice as many Arab Americans, in percentage terms, earn degrees beyond the bachelor's degree. Key factorsin this question are country of origin, length of time in the United States and gender.
 
 33. What occupations do Arab Americans pursue?
 
-Arab Americans work in all occupations. Collectively, they are more likely
-to be self-employed or to be entrepreneurs or to work in sales. About 60
-percent of working Arab Americans are executives, professionals, office and
-sales staff. At the local level, Arab Americans are most likely to be
-executives in Washington, D.C., and Anaheim, Calif.; sales people in
-Cleveland and Anaheim, and manufacturing workers in Detroit. As with all
-people, employment choices may be influenced by nationality, religion,
-education, socio-economic status and gender.
+Arab Americans work in all occupations. Collectively, they are more likely to be self-employed or to be entrepreneurs or to work in sales. About 60 percent of working Arab Americans are executives, professionals, office and sales staff. At the local level, Arab Americans are most likely to be executives in Washington, D.C., and Anaheim, Calif.; sales people in Cleveland and Anaheim, and manufacturing workers in Detroit. As with all people, employment choices may be influenced by nationality, religion, education, socio-economic status and gender.
 
 34. How do Arab Americans fare economically?
 
-Individually, Arab Americans are at every economic strata of American life.
-Nationally, Arab-American households have a higher than average median
-income. Like occupational patterns, this varies by location. Arab-American
-earnings are below the overall average income in Detroit and Anaheim.
+Individually, Arab Americans are at every economic strata of American life. Nationally, Arab-American households have a higher than average median income. Like occupational patterns, this varies by location. Arab-American earnings are below the overall average income in Detroit and Anaheim.
 
 ## Family
 
 35. What is the role of the family in Arab culture?
 
-The variety of family types among Arab Americans is vast, and influenced by
-the same factors mentioned in the answer to Question 33. Generally, family
-is more important than the individual and more influential than nationality.
-People draw much of their identity from their role in the family.
-Historically, this has fostered immigration in which members of an extended
-family or clan help one another immigrate.
+The variety of family types among Arab Americans is vast, and influenced by the same factors mentioned in the answer to Question 33. Generally, family is more important than the individual and more influential than nationality. People draw much of their identity from their role in the family. Historically, this has fostered immigration in which members of an extended family or clan help one another immigrate.
 
 36. Do Arab Americans maintain ties with their home countries?
 
-Many do. They are very proud of their home countries and may maintain
-regular contact with relatives or friends there, as many Americans do. Arab
-Americans will sometimes joke with one another over which of their home
-countries is the best, but it is perfectly consistent to have loyalties both
-to their place of origin and their country of citizenship.
+Many do. They are very proud of their home countries and may maintain regular contact with relatives or friends there, as many Americans do. Arab Americans will sometimes joke with one another over which of their home countries is the best, but it is perfectly consistent to have loyalties both to their place of origin and their country of citizenship.
 
 37. What are gender roles like for Arab Americans?
 
-These vary tremendously. Some of the variables are country of origin,
-whether the family came from a rural or urban area and how long the person's
-family has been in the United States. It is more accurate to ask the subject
-of the story about his or her own experience than to apply a stereotype.
+These vary tremendously. Some of the variables are country of origin, whether the family came from a rural or urban area and how long the person's family has been in the United States. It is more accurate to ask the subject of the story about his or her own experience than to apply a stereotype.
 
 38. Do Arab Americans have large families?
 
-Arab-American families are, on average, larger than non-Arab-American
-families and smaller than families in Arab countries. Traditionally, more
-children meant more pride and economic contributors for the family. The cost
-of having large families in the United States, however, and adaptation to
-American customs seem to encourage smaller families.
+Arab-American families are, on average, larger than non-Arab-American families and smaller than families in Arab countries. Traditionally, more children meant more pride and economic contributors for the family. The cost of having large families in the United States, however, and adaptation to American customs seem to encourage smaller families.
 
 39. What kind of relationship does cousin mean to Arab Americans?
 
-The same as for other Americans, though Arabs may differentiate between
-maternal and paternal cousins when they refer to them.
+The same as for other Americans, though Arabs may differentiate between maternal and paternal cousins when they refer to them.
 
 40. Do generations of Arab Americans live together?
 
-Sometimes, especially with people who have more recently arrived in the
-United States, but this can be true of non-Arabs as well and is not a
-distinguishing characteristic of Arab Americans.
+Sometimes, especially with people who have more recently arrived in the United States, but this can be true of non-Arabs as well and is not a distinguishing characteristic of Arab Americans.
 
 41. Do Arab Americans typically get married at a younger age than non-Arabs?
 
-Yes, though this is changing. As women follow careers, they are not expected
-to marry so young. Arab women might also marry older men who can provide
-greater financial security.
+Yes, though this is changing. As women follow careers, they are not expected to marry so young. Arab women might also marry older men who can provide greater financial security.
 
 42. Are marriages arranged?
 
-This is very rare, except among the most recent immigrants. Remember that
-most Arab Americans were born here, and that they frequently marry people
-from other cultures. In the case where a marriage is arranged, a parent may
-recommend someone from another family or from the country of origin, but the
-child is not forced to marry that person. More typically, couples meet and
-ask their families' approval before getting engaged, or make their own
-decision and then tell their families.
+This is very rare, except among the most recent immigrants. Remember that most Arab Americans were born here, and that they frequently marry people from other cultures. In the case where a marriage is arranged, a parent may recommend someone from another family or from the country of origin, but the child is not forced to marry that person. More typically, couples meet and ask their families' approval before getting engaged, or make their own decision and then tell their families.
 
 43. Do Arab Americans prefer to marry each other?
 
-As with many people, in-group marriage may be encouraged as a way to
-preserve heritage, but Arabs and non-Arabs frequently marry one other.
-Religious differences among Arab Americans, in fact, may make it more
-desirable to marry a non-Arab of similar religious background than an Arab
-of a different religion.
+As with many people, in-group marriage may be encouraged as a way to preserve heritage, but Arabs and non-Arabs frequently marry one other. Religious differences among Arab Americans, in fact, may make it more desirable to marry a non-Arab of similar religious background than an Arab of a different religion.
 
 44. Are there any Arab conventions for naming children?
 
-Muslims often name their children after prophets in the Quran. ShiÕa Muslims
-sometimes use Ali as a middle name. Christians often name their children
-after people in the Bible. Although names can give an indication of a
-person's religion, don't assume. Arab tradition may call for the father's
-name to be the middle name of sons and daughters.
+Muslims often name their children after prophets in the Quran. ShiÕa Muslims sometimes use Ali as a middle name. Christians often name their children after people in the Bible. Although names can give an indication of a person's religion, don't assume. Arab tradition may call for the father's name to be the middle name of sons and daughters.
 
 45. What does the title Umm or Abu mean as part of a name?
 
-It is a common way of calling someone using their oldest son's name. Umm
-means mother of. Abu means father of. "Umm Muhammad" is "mother of
-Muhammad." This is what friends might call her, as a sign of respect.
+It is a common way of calling someone using their oldest son's name. Umm means mother of. Abu means father of. "Umm Muhammad" is "mother of Muhammad." This is what friends might call her, as a sign of respect.
 
 46. What do Arabs mean when they refer to someone as Auntie?
 
-It is a sign of respect, not necessarily family relationship. An Arab
-American might call any older Arab male or female "auntie" or "uncle." Many
-Arab Americans do not use these terms at all. Journalists can show respect
-by using courtesy titles.
+It is a sign of respect, not necessarily family relationship. An Arab American might call any older Arab male or female "auntie" or "uncle." Many Arab Americans do not use these terms at all. Journalists can show respect by using courtesy titles.
 
 Customs
 
 47. Why do some Arab women wear garments that cover their faces or heads?
 
-This is a religious practice, not a cultural practice. It is rooted in
-Islamic teachings about hijab, or modesty. While some say that veiling
-denigrates women, some women say that it liberates them. Covering is not
-universally observed by Muslim women and varies by region and class. Some
-Arab governments have, at times, banned or required veiling. In American
-families, a mother or daughter may cover her head while the other does not.
+This is a religious practice, not a cultural practice. It is rooted in Islamic teachings about hijab, or modesty. While some say that veiling denigrates women, some women say that it liberates them. Covering is not universally observed by Muslim women and varies by region and class. Some Arab governments have, at times, banned or required veiling. In American families, a mother or daughter may cover her head while the other does not.
 
 48. What garments might a woman wear to practice hijab?
 
-One interpretation is that everything should be covered except hands, face
-and feet. Long clothing and a scarf would accomplish this and the head scarf
-might be called a hijab or chador. The long, robelike garment is called an
-abayah, jilbab, or chador. In Iraq and Saudi Arabia especially, a woman may
-wear a cloak that covers her head. Beneath a robe, a woman may be wearing a
-traditional dress, casual clothes or a business suit. The veil, in
-particular, has been made controversial by governments, gender politics and
-religious biases. Most Muslim women in the United States do not wear veils.
+One interpretation is that everything should be covered except hands, face and feet. Long clothing and a scarf would accomplish this and the head scarf might be called a hijab or chador. The long, robelike garment is called an abayah, jilbab, or chador. In Iraq and Saudi Arabia especially, a woman may wear a cloak that covers her head. Beneath a robe, a woman may be wearing a traditional dress, casual clothes or a business suit. The veil, in particular, has been made controversial by governments, gender politics and religious biases. Most Muslim women in the United States do not wear veils.
 
 49. Some Arab men wear a checked garment on their heads. What is that?
 
-It is called a kafiyyeh and it is traditional, not religious. Wearing the
-kafiyyeh is similar to an African American wearing traditional African
-attire, or an Indian wearing a sari. The kafiyyeh shows identity and pride
-in one's culture.
+It is called a kafiyyeh and it is traditional, not religious. Wearing the kafiyyeh is similar to an African American wearing traditional African attire, or an Indian wearing a sari. The kafiyyeh shows identity and pride in one's culture.
 
 50. Why do some Arab women dress in black?
 
@@ -421,76 +235,37 @@ Remember that black is a popular color in contemporary American fashion and may 
 
 51. What is an appropriate way to greet an Arab American?
 
-This is not difficult or tricky. Remember that most Arab Americans grew up
-here and do not require special greetings. Be yourself, and let them be
-themselves. If they are practicing Muslims or recent immigrants, watch for
-cues. A smile, a nod and a word of greeting are appropriate in most
-situations. Some Muslims feel it is inappropriate for unrelated men and
-women to shake hands. Wait until the other person extends his or her hand
-before you extend your own.
+This is not difficult or tricky. Remember that most Arab Americans grew up here and do not require special greetings. Be yourself, and let them be themselves. If they are practicing Muslims or recent immigrants, watch for cues. A smile, a nod and a word of greeting are appropriate in most situations. Some Muslims feel it is inappropriate for unrelated men and women to shake hands. Wait until the other person extends his or her hand before you extend your own.
 
 52. What are the customs for paying compliments?
 
-Again, be yourself and be observant. In most cases, there is no reason to
-behave differently than you would with anyone else. For some recent
-immigrants, be a little more reserved. Complimenting a possession may be
-misunderstood and the person, out of generosity and hospitality, may feel
-compelled to offer you the object. There can be a lot of difference between
-one person and another, even a parent and child, so don't assume one way is
-always best.
+Again, be yourself and be observant. In most cases, there is no reason to behave differently than you would with anyone else. For some recent immigrants, be a little more reserved. Complimenting a possession may be misunderstood and the person, out of generosity and hospitality, may feel compelled to offer you the object. There can be a lot of difference between one person and another, even a parent and child, so don't assume one way is always best.
 
 53. What about gift-giving?
 
-The giving of token gifts is a polite practice in many cultures and American
-businesses. A gift, then, can put journalistic integrity and cultural
-sensitivity into conflict. You will have to balance your journalistic ethics
-against the risk of offending someone by refusing a gift. Consider your
-ethics policy, the giver's intention, the effects of acceptance or denial,
-as well as the value of the gift. You may need to consult with your
-supervisor or explain yourself to the giver.
+The giving of token gifts is a polite practice in many cultures and American businesses. A gift, then, can put journalistic integrity and cultural sensitivity into conflict. You will have to balance your journalistic ethics against the risk of offending someone by refusing a gift. Consider your ethics policy, the giver's intention, the effects of acceptance or denial, as well as the value of the gift. You may need to consult with your supervisor or explain yourself to the giver.
 
 54. What is Middle-Eastern food like?
 
-Tasty! It is varied, but has some staples. Wheat is used in bread, pastries,
-salads and main dishes. Rice is often cooked with vegetables, lamb, chicken
-or beef. Lamb and mutton are more common than other meats. Arab recipes use
-many beans and vegetables, including eggplant, zucchini, cauliflower,
-spinach, onions, parsley and chickpeas.
+Tasty! It is varied, but has some staples. Wheat is used in bread, pastries, salads and main dishes. Rice is often cooked with vegetables, lamb, chicken or beef. Lamb and mutton are more common than other meats. Arab recipes use many beans and vegetables, including eggplant, zucchini, cauliflower, spinach, onions, parsley and chickpeas.
 
 55. What is that pipe I sometimes see people smoking?
 
-It is a water pipe that filters and cools tobacco smoke, which often is
-flavored with apple, honey, strawberry, mint, mango or apricot. Such pipes
-are used in several parts of the world and are not an exclusively Arab
-apparatus. They are known by several names, including sheesha, hookah and
-argilah, or argeelah.
+It is a water pipe that filters and cools tobacco smoke, which often is flavored with apple, honey, strawberry, mint, mango or apricot. Such pipes are used in several parts of the world and are not an exclusively Arab apparatus. They are known by several names, including sheesha, hookah and argilah, or argeelah.
 
 Religion
 
 56. Do most Arab Americans belong to the same religion?
 
-Most Arab Americans are Christian, though this varies by region. In many
-communities, Muslim and Christian Arabs live side by side with each other
-and with non-Arab religious communities. Most Arab countries are
-predominantly Muslim.
+Most Arab Americans are Christian, though this varies by region. In many communities, Muslim and Christian Arabs live side by side with each other and with non-Arab religious communities. Most Arab countries are predominantly Muslim.
 
 57. Is Islam mostly an Arab religion, then?
 
-No. Only about 12 percent of Muslims worldwide are Arabs. There are more
-Muslims in Indonesia, for example, than in all Arab countries combined.
-Large populations of Muslims also live in India, Iran, other parts of East
-Asia and sub-Saharan Africa. Islam has a strong Arab flavor, though, as the
-religion's holiest places are in the Middle East, and the Quran was
-originally written in Arabic.
+No. Only about 12 percent of Muslims worldwide are Arabs. There are more Muslims in Indonesia, for example, than in all Arab countries combined. Large populations of Muslims also live in India, Iran, other parts of East Asia and sub-Saharan Africa. Islam has a strong Arab flavor, though, as the religion's holiest places are in the Middle East, and the Quran was originally written in Arabic.
 
 58. What is the Quran (or Koran)?
 
-The Quran is the holy book for Muslims, who believe it contains the word of
-God revealed to the prophet Muhammad. The Quran has many passages that are
-similar to those in the Bible, which Muslims also regard as a holy book. The
-Quran has been translated into many languages, including English, and is
-available on the Web. 'Quran' is Associated Press style. Other spellings are
-Qur'an and Koran. Variations come from transliterating Arabic into English.
+The Quran is the holy book for Muslims, who believe it contains the word of God revealed to the prophet Muhammad. The Quran has many passages that are similar to those in the Bible, which Muslims also regard as a holy book. The Quran has been translated into many languages, including English, and is available on the Web. 'Quran' is Associated Press style. Other spellings are Qur'an and Koran. Variations come from transliterating Arabic into English.
 
 For a complete online text of the Koran in English click here.
 
@@ -498,139 +273,75 @@ Note: Read AMALID's article on the Problematic Verses In The Koran.
 
 59. What is the difference between Islam and Muslim?
 
-Islam is the religion, and a Muslim is a follower of the religion. It is
-like the difference between Christianity and Christian. The adjective form
-is Islamic.
+Islam is the religion, and a Muslim is a follower of the religion. It is like the difference between Christianity and Christian. The adjective form is Islamic.
 
 60. What are the five pillars of Islam?
 
-The five pillars are minimum sacred obligations for followers who are able
-to observe them. They are: belief in the shehada, the statement that "There
-is no god but God, and Muhammad is his prophet"; salat, or prayer five times
-a day; zakat, the sharing of alms with the poor; fasting during the holy
-month of Ramadan, and the hajj, or pilgrimage to Mecca in Saudi Arabia.
+The five pillars are minimum sacred obligations for followers who are able to observe them. They are: belief in the shehada, the statement that "There is no god but God, and Muhammad is his prophet"; salat, or prayer five times a day; zakat, the sharing of alms with the poor; fasting during the holy month of Ramadan, and the hajj, or pilgrimage to Mecca in Saudi Arabia.
 
 61. What is Ramadan?
 
-Ramadan, the ninth month of the Muslim calendar, is a month of fasting whose
-end is marked with the celebration of Eid al-Fitr. During this month of
-self-discipline and purification, Muslims abstain from food, drink and sex
-from before sunrise until sundown. At night, however, they may feast. The
-Islamic calendar is based on the cycles of the moon and has 354 days, so
-Ramadan does not always occur at the same time of year according to the
-365-day civil calendar.
+Ramadan, the ninth month of the Muslim calendar, is a month of fasting whose end is marked with the celebration of Eid al-Fitr. During this month of self-discipline and purification, Muslims abstain from food, drink and sex from before sunrise until sundown. At night, however, they may feast. The Islamic calendar is based on the cycles of the moon and has 354 days, so Ramadan does not always occur at the same time of year according to the 365-day civil calendar.
 
 62. What is the proper greeting during Ramadan?
 
-You may say, "Ramadan Mubarrak." You could also say, "Salaam," which means
-"peace" and is useful at any time. If you are planning to meet with Muslims
-during Ramadan, be aware that they may be fasting and a meal-time meeting
-may be awkward.
+You may say, "Ramadan Mubarrak." You could also say, "Salaam," which means "peace" and is useful at any time. If you are planning to meet with Muslims during Ramadan, be aware that they may be fasting and a meal-time meeting may be awkward.
 
 63. Must Arabs make a journey to Mecca?
 
-This relates to Muslims, not all Arabs. Learn to keep that distinction in
-mind. Muslims who are financially and physically able to do so are expected
-to make the journey at least once in their lifetime.
+This relates to Muslims, not all Arabs. Learn to keep that distinction in mind. Muslims who are financially and physically able to do so are expected to make the journey at least once in their lifetime.
 
 64. What does hajj mean?
 
-Al hajj refers to the pilgrimage to Mecca by millions of Muslims once each
-year. It is a milestone event in a Muslim's life. A man who makes the trip
-is recognized with the title hajji, which means pilgrim. For women, the
-title is hajjah.
+Al hajj refers to the pilgrimage to Mecca by millions of Muslims once each year. It is a milestone event in a Muslim's life. A man who makes the trip is recognized with the title hajji, which means pilgrim. For women, the title is hajjah.
 
 65. What is the difference between Sunni and Shi'a Muslims?
 
-Historically, these are the two main branches of Islam, and their
-distinction has to do with the successor of the prophet Muhammad. Sunnis
-believe his successors were elected religious leaders; Shi'a believe that
-the prophet appointed Ali ibn Abi Taleb. The answer is much more complicated
-than this, though, because there are other differences and new ones have
-arisen over the years. There also are separate groups and movements within
-each branch. In the United States, Muslim unity often overshadows the
-divisions. Most Muslims worldwide and in the United States are Sunni, though
-Shi'as dominate in some communities. Most Muslims in Iraq, Bahrain, Lebanon
-and the non-Arab country of Iran are Shi'a.
+Historically, these are the two main branches of Islam, and their distinction has to do with the successor of the prophet Muhammad. Sunnis believe his successors were elected religious leaders; Shi'a believe that the prophet appointed Ali ibn Abi Taleb. The answer is much more complicated than this, though, because there are other differences and new ones have arisen over the years. There also are separate groups and movements within each branch. In the United States, Muslim unity often overshadows the divisions. Most Muslims worldwide and in the United States are Sunni, though Shi'as dominate in some communities. Most Muslims in Iraq, Bahrain, Lebanon and the non-Arab country of Iran are Shi'a.
 
 66. Are there restrictions on entering a mosque?
 
-One generally must enter without shoes. Look for a sign from your host, or
-for a place to leave your shoes. Women should dress modestly and may be
-asked to cover their heads. Men should wear long pants and shirts. Men and
-women generally pray in different areas.
+One generally must enter without shoes. Look for a sign from your host, or for a place to leave your shoes. Women should dress modestly and may be asked to cover their heads. Men should wear long pants and shirts. Men and women generally pray in different areas.
 
 67. Is it OK to take pictures there?
 
-Each mosque has its own rules. Ask in advance and do not assume it will be
-OK to photograph at will. Be prepared to make some accommodations if certain
-angles or parts of the mosque are off limits.
+Each mosque has its own rules. Ask in advance and do not assume it will be OK to photograph at will. Be prepared to make some accommodations if certain angles or parts of the mosque are off limits.
 
 68. Who is an imam?
 
-The leader of prayer at a mosque. He might also be called a sheik. One of an
-imam's responsibilities is to give sermons on Friday, the holiest day of the
-typical Islamic week. In many American mosques, the imam is also the
-administrator. To journalists, an imam can be an important community leader
-and a good source of information about local Muslims.
+The leader of prayer at a mosque. He might also be called a sheik. One of an imam's responsibilities is to give sermons on Friday, the holiest day of the typical Islamic week. In many American mosques, the imam is also the administrator. To journalists, an imam can be an important community leader and a good source of information about local Muslims.
 
 69. What are important Islamic holidays?
 
-The most important Muslim observance each year is Ramadan. Muslims also
-celebrate Eid al-Adha on the last day of the hajj -- the pilgrimage to Mecca
--- and Eid al-Fitr, at the end of Ramadan. Depending on the makeup of your
-area, these are worthy of consideration as news events. There are other
-holidays, as well, but do not assume that a holiday or practice observed at
-one mosque is observed by all.
+The most important Muslim observance each year is Ramadan. Muslims also celebrate Eid al-Adha on the last day of the hajj -- the pilgrimage to Mecca -- and Eid al-Fitr, at the end of Ramadan. Depending on the makeup of your area, these are worthy of consideration as news events. There are other holidays, as well, but do not assume that a holiday or practice observed at one mosque is observed by all.
 
 70. Where is the headquarters for Islam?
 
-Islam does not have the same kind of hierarchy as some other religions.
-There is no top official or ruling board for Islam. Muslim mosques, or
-masjids, and associations are independent. Muslims are not required to be
-members of a mosque.
+Islam does not have the same kind of hierarchy as some other religions. There is no top official or ruling board for Islam. Muslim mosques, or masjids, and associations are independent. Muslims are not required to be members of a mosque.
 
 71. Why do some Arab men decline to shake hands with women?
 
-Some Muslim men, for religious reasons, avoid physical contact with women
-other than close relatives. This is not true for all Muslims and exceptions
-are made to help women who are injured, crossing the street, etc.
+Some Muslim men, for religious reasons, avoid physical contact with women other than close relatives. This is not true for all Muslims and exceptions are made to help women who are injured, crossing the street, etc.
 
 72. Is the Nation of Islam related to Islam?
 
-This African American religious group is closely related to Islam, but
-evolved in the 20th Century with some different practices than those
-followed by most Muslims. Most African-American Muslims in the United States
-are not part of the Nation of Islam.
+This African American religious group is closely related to Islam, but evolved in the 20th Century with some different practices than those followed by most Muslims. Most African-American Muslims in the United States are not part of the Nation of Islam.
 
 73. What is Eastern rite or Eastern Orthodox?
 
-e careful. These are designations for Christian churches that share some
-similarities, but that have different histories. Eastern rite churches are
-part of the Catholic church with roots in the Middle East and include
-Maronites, Melkites and Chaldeans. Eastern Orthodox churches, which are
-independent from Vatican authority, include the Syrian and Coptic churches.
+e careful. These are designations for Christian churches that share some similarities, but that have different histories. Eastern rite churches are part of the Catholic church with roots in the Middle East and include Maronites, Melkites and Chaldeans. Eastern Orthodox churches, which are independent from Vatican authority, include the Syrian and Coptic churches.
 
 74. Who are Coptics?
 
-The word Copt is derived from the Greek word for Egyptian and Coptic was the
-native language of Egypt before Arabic prevailed. Today, the word refers to
-Coptic Christians. Although linguistically and culturally classified as
-Arabs, many consider themselves to be ethnically distinct from other
-Egyptians.
+The word Copt is derived from the Greek word for Egyptian and Coptic was the native language of Egypt before Arabic prevailed. Today, the word refers to Coptic Christians. Although linguistically and culturally classified as Arabs, many consider themselves to be ethnically distinct from other Egyptians.
 
 75. What does Allah mean?
 
-Allah means God. The same word is used by Arabic-speaking Christians,
-Muslims and Jews. When translating Arabic expressions, translate all the
-words, for consistency. The translation of "Allahu Akbar," for example,
-would be "God is great," not "Allah is great."
+Allah means God. The same word is used by Arabic-speaking Christians, Muslims and Jews. When translating Arabic expressions, translate all the words, for consistency. The translation of "Allahu Akbar," for example, would be "God is great," not "Allah is great."
 
 76. Why do Muslims face east when they pray?
 
-They are facing Kaaba (the House of God) at Mecca, the holiest of the three
-cities of Islam. Muslims in other countries face different directions,
-depending on where they are in relation to Mecca.
+They are facing Kaaba (the House of God) at Mecca, the holiest of the three cities of Islam. Muslims in other countries face different directions, depending on where they are in relation to Mecca.
 
 77. What are the other two holy cities?
 
@@ -640,48 +351,25 @@ Medina in Saudi Arabia and Jerusalem.
 
 78. Are Arab Americans active in U.S. politics?
 
-Yes. For decades, Arab Americans have voted, run for office and been
-elected. According to John L. Zogby, a pollster who is Arab American, 86
-percent of voting-age Arab Americans in early 2000 were registered voters.
-In 1996, exit polls said 54 percent of the Arab-American vote was for Bill
-Clinton, 38 percent went for Bob Dole and 7.7 percent went for independent
-candidate H. Ross Perot. The 2000 campaign was the first in which both major
-presidential candidates addressed Arab Americans.
+Yes. For decades, Arab Americans have voted, run for office and been elected. According to John L. Zogby, a pollster who is Arab American, 86 percent of voting-age Arab Americans in early 2000 were registered voters. In 1996, exit polls said 54 percent of the Arab-American vote was for Bill Clinton, 38 percent went for Bob Dole and 7.7 percent went for independent candidate H. Ross Perot. The 2000 campaign was the first in which both major presidential candidates addressed Arab Americans.
 
 79. Have Arab Americans won major political offices?
 
-Yes. In 1998, for example, 12 Arab Americans campaigned for the U.S.
-Congress in 10 states.
+Yes. In 1998, for example, 12 Arab Americans campaigned for the U.S. Congress in 10 states.
 
 80. Who are some prominent Arab-American politicians?
 
-They have included U.S. Senate Majority Leader George Mitchell, D-Maine;
-Energy Secretary Spencer Abraham; former secretary of Health and Human
-Services Donna Shalala; New Hampshire Gov. Jeanne Shaheen; former New
-Hampshire governor and White House chief of staff John Sununu, and 2000
-presidential candidate Ralph Nader.
+They have included U.S. Senate Majority Leader George Mitchell, D-Maine; Energy Secretary Spencer Abraham; former secretary of Health and Human Services Donna Shalala; New Hampshire Gov. Jeanne Shaheen; former New Hampshire governor and White House chief of staff John Sununu, and 2000 presidential candidate Ralph Nader.
 
 81. Is there an Arab lobby?
 
-There is not an Arab lobby in the sense of a monolithic, controlling body.
-There are several organizations that lobby in behalf of a variety of issues,
-including domestic and international concerns. One is the Arab American
-Institute, which supports presidential and congressional candidates who are
-receptive to Arab-American concerns. Another is the American Arab
-Anti-Discrimination Committee, a civil rights group.
+There is not an Arab lobby in the sense of a monolithic, controlling body. There are several organizations that lobby in behalf of a variety of issues, including domestic and international concerns. One is the Arab American Institute, which supports presidential and congressional candidates who are receptive to Arab-American concerns. Another is the American Arab Anti-Discrimination Committee, a civil rights group.
 
 ## Terminology
 
 82. Should I say Arab, Arabic or Arabian?
 
-Arab is a noun for a person, and is used as an adjective, as in "Arab
-country." Arabic is the name of the language and generally is not used as an
-adjective. Arabian is an adjective that refers to Saudi Arabia, the Arabian
-Peninsula, or as in Arabian horse. When ethnicity or nationality are
-relevant, it is more precise and accurate to specify the country by using
-Lebanese, Yemeni or whatever is appropriate. We suggest that you hyphenate
-when using Arab-American as an adjective, as in Arab-American issues, but do
-not hyphenate when saying that someone is an Arab American.
+Arab is a noun for a person, and is used as an adjective, as in "Arab country." Arabic is the name of the language and generally is not used as an adjective. Arabian is an adjective that refers to Saudi Arabia, the Arabian Peninsula, or as in Arabian horse. When ethnicity or nationality are relevant, it is more precise and accurate to specify the country by using Lebanese, Yemeni or whatever is appropriate. We suggest that you hyphenate when using Arab-American as an adjective, as in Arab-American issues, but do not hyphenate when saying that someone is an Arab American.
 
 83. Is Arab American, or American Arab preferred?
 
@@ -689,29 +377,15 @@ Arab American but, again, if you can be more specific, do so.
 
 84. How should I refer to an Arab-American individual?
 
-Preferably by the country that person is from, for example, "of Lebanese
-heritage," or "of Jordanian descent," but only if ethnicity is relevant.
-Remember that Arab Americans come from many places, and you should include
-the relevant perspective. If the story is about an issue that affects
-Yemenis, for example, don't treat other Arabic perspectives as
-interchangeable.
+Preferably by the country that person is from, for example, "of Lebanese heritage," or "of Jordanian descent," but only if ethnicity is relevant. Remember that Arab Americans come from many places, and you should include the relevant perspective. If the story is about an issue that affects Yemenis, for example, don't treat other Arabic perspectives as interchangeable.
 
 85. What if the story is about Arab Americans whose ethnicity is not
 
-relevant to the story?
-Then there is no need to identify their ethnicity. It is important to
-include Arab Americans even when the story is about issues unrelated to
-heritage or culture. Arab Americans are teachers, lawyers, grocers,
-executives and students. Their views are important to many stories. If
-journalists confine Arab Americans to stories about Arab issues, other
-facets of their experience are ignored and the overall portrayal is
-one-dimensional.
+relevant to the story? Then there is no need to identify their ethnicity. It is important to include Arab Americans even when the story is about issues unrelated to heritage or culture. Arab Americans are teachers, lawyers, grocers, executives and students. Their views are important to many stories. If journalists confine Arab Americans to stories about Arab issues, other facets of their experience are ignored and the overall portrayal is one-dimensional.
 
 86. What does Mohammedanism mean?
 
-Do not use Mohammedan and its derivatives. Instead, use Islam for the
-religion, Muslim for a follower of the religion and derivatives of these
-words.
+Do not use Mohammedan and its derivatives. Instead, use Islam for the religion, Muslim for a follower of the religion and derivatives of these words.
 
 87. Is it Muslim or Moslem?
 
@@ -719,116 +393,59 @@ Muslim.
 
 88. Who is a sheik?
 
-A sheik can be the leader of a family, a village, a tribe or a mosque. Press
-accounts popularized the term "oil-rich sheik." This contributed to the
-misconception that the people who became wealthy from oil were sheiks, and
-that sheiks had oil money. Neither is true.
+A sheik can be the leader of a family, a village, a tribe or a mosque. Press accounts popularized the term "oil-rich sheik." This contributed to the misconception that the people who became wealthy from oil were sheiks, and that sheiks had oil money. Neither is true.
 
 ## Stereotypes
 
 89. Are Arabs oil-rich?
 
-Some are, most aren't. The area around the Persian Gulf is one of several
-oil-producing areas in the world, but not all Arab countries produce oil,
-and very few Arabs are rich from oil.
+Some are, most aren't. The area around the Persian Gulf is one of several oil-producing areas in the world, but not all Arab countries produce oil, and very few Arabs are rich from oil.
 
 90. Are Arabs mostly a nomadic people?
 
-No. Most live in urban areas, but portrayals of Arabs as desert dwellers
-have distorted the picture. Bedouins, nomadic people depicted in movies,
-make up only about 2 percent of Arab people. One of the largest Arab cities
-is Cairo, with a population of more than 6 million.
+No. Most live in urban areas, but portrayals of Arabs as desert dwellers have distorted the picture. Bedouins, nomadic people depicted in movies, make up only about 2 percent of Arab people. One of the largest Arab cities is Cairo, with a population of more than 6 million.
 
 91. Do Arabs come from the desert?
 
-Most do not. To begin with, most Arabs live in cities. Secondly, Arab
-countries have a range of climates. Many have coastal areas and some have
-mountainous areas that get snow. Arab people come from a variety of
-latitudes that extend from as far south as just below the equator to as far
-north as approximately Lexington, Ky.
+Most do not. To begin with, most Arabs live in cities. Secondly, Arab countries have a range of climates. Many have coastal areas and some have mountainous areas that get snow. Arab people come from a variety of latitudes that extend from as far south as just below the equator to as far north as approximately Lexington, Ky.
 
 92. Are Arabs frequently involved in terrorism?
 
-No more so than other groups of people. Many types of people have committed
-acts of terror. However, news accounts seem to more often stress Arab
-connections than they do for terrorism committed by other groups. In
-addition, there have been highly publicized cases when Arabs were singled
-out, early on and erroneously, as suspects. The Oklahoma City federal
-building bombing in 1995 was one such case.
+No more so than other groups of people. Many types of people have committed acts of terror. However, news accounts seem to more often stress Arab connections than they do for terrorism committed by other groups. In addition, there have been highly publicized cases when Arabs were singled out, early on and erroneously, as suspects. The Oklahoma City federal building bombing in 1995 was one such case.
 
 93. What is meant by the phrase "Islamic fundamentalist"?
 
-This is complex. The term fundamentalist, whether applied to Muslims or
-Christians, is a largely American construct that has been used to imply
-politically conservatism and, sometimes, extremism. The term "Islamic
-fundamentalist" has been used to refer to people who use Islam to justify
-political actions. This has blurred the distinction between religion and
-politics. Because of this, acts carried out for political reasons are
-sometimes attributed to religion. Fairness and accuracy mean attributing
-political actions to the group, government or party responsible, and not to
-a religion, which may have millions of followers around the world. Avoid
-constructions like "Muslim bomb."
+This is complex. The term fundamentalist, whether applied to Muslims or Christians, is a largely American construct that has been used to imply politically conservatism and, sometimes, extremism. The term "Islamic fundamentalist" has been used to refer to people who use Islam to justify political actions. This has blurred the distinction between religion and politics. Because of this, acts carried out for political reasons are sometimes attributed to religion. Fairness and accuracy mean attributing political actions to the group, government or party responsible, and not to a religion, which may have millions of followers around the world. Avoid constructions like "Muslim bomb."
 
 94. Is Islam a violent religion?
 
-The Quran teaches nonviolence. Throughout history, political groups and
-leaders have used Islam and other religions to justify many things,
-including violence.
+The Quran teaches nonviolence. Throughout history, political groups and leaders have used Islam and other religions to justify many things, including violence.
 
 AMALID Note:There are "Problematic Verses In The Koran" though that are very violent.
 
 95. Are Arab-American women subservient to men?
 
-No sweeping statement can reflect all the roles of Arab women. They range
-from leaders of matriarchal societies to independent businesswomen to
-extreme deference. Their roles are affected by their country of origin,
-whether they are from urban or rural areas, religion, degree of assimilation
-and, of course, their own, individual characteristics.
+No sweeping statement can reflect all the roles of Arab women. They range from leaders of matriarchal societies to independent businesswomen to extreme deference. Their roles are affected by their country of origin, whether they are from urban or rural areas, religion, degree of assimilation and, of course, their own, individual characteristics.
 
 96. What is that charm with the eye or an eye on a hand?
 
-Often worn as jewelry, the hamsa is a non-religious symbol for protection or
-good luck. The eye, usually blue when colored, wards off the evil eye or
-evil spirits. For example, the charm may be put on a baby to protect the
-child from harm. This cultural tradition is shared by many people of
-different religions.
+Often worn as jewelry, the hamsa is a non-religious symbol for protection or good luck. The eye, usually blue when colored, wards off the evil eye or evil spirits. For example, the charm may be put on a baby to protect the child from harm. This cultural tradition is shared by many people of different religions.
 
 ## Coverage
 
 97. How can I find Arab Americans in my community?
 
-In cities where there are large populations, this is easy. You can find
-restaurants, stores, markets and other businesses with Arabic names or
-writing on them. Look for organizations, community centers, churches and
-mosques that might be Arab-related. Use these as beginning points, and don't
-keep going back to the same people, or focus only on recent immigrants. To
-find Arab Americans in places where they are less prevalent, try some of the
-organizations in Resources.
+In cities where there are large populations, this is easy. You can find restaurants, stores, markets and other businesses with Arabic names or writing on them. Look for organizations, community centers, churches and mosques that might be Arab-related. Use these as beginning points, and don't keep going back to the same people, or focus only on recent immigrants. To find Arab Americans in places where they are less prevalent, try some of the organizations in Resources.
 
 98. Are there issues about the way Arab Americans are portrayed in the
 media?
 
-Yes. In some cases, journalists seem to prefer to publish or air images of
-people who look different, or exotic. In trying for a more interesting
-image, they may emphasize the difference between Arab Americans and non-Arab
-Americans. Most Arab Americans do not wear traditional clothing. News
-organizations whose collective reports give the impression that Arab
-Americans generally dress differently than non-Arab Americans are being
-inaccurate.
+Yes. In some cases, journalists seem to prefer to publish or air images of people who look different, or exotic. In trying for a more interesting image, they may emphasize the difference between Arab Americans and non-Arab Americans. Most Arab Americans do not wear traditional clothing. News organizations whose collective reports give the impression that Arab Americans generally dress differently than non-Arab Americans are being inaccurate.
 
 99. Is there a coverage pitfall that reporters should avoid?
 
-Like many groups, Arab Americans say that reporters stay away unless there
-is a problem to report, or if there is a national or international crisis
-for which they want reaction. This keeps people out of sight except when
-they are associated with trouble. The solution is to cover Arab Americans
-consistently and continuously. By paying attention to what communities say
-are significant news issues, reporters offer deeper and fuller coverage.
+Like many groups, Arab Americans say that reporters stay away unless there is a problem to report, or if there is a national or international crisis for which they want reaction. This keeps people out of sight except when they are associated with trouble. The solution is to cover Arab Americans consistently and continuously. By paying attention to what communities say are significant news issues, reporters offer deeper and fuller coverage.
 
 100. How can I learn more?
 
-We're glad you asked. This resource guide is just an introduction. Any one
-of the 100 questions in it has answers that would fill a book. We have
-listed some resources for further study in the following pages. We also
-encourage you to get out and talk to people, and to invite them to visit
-your newsroom.
+We're glad you asked. This resource guide is just an introduction. Any one of the 100 questions in it has answers that would fill a book. We have listed some resources for further study in the following pages. We also encourage you to get out and talk to people, and to invite them to visit your newsroom.

--- a/pages/home.md
+++ b/pages/home.md
@@ -25,15 +25,11 @@ I want to build an integration from Github to an LLM (such as Gemini) to review 
 
 ## TODO 
 
-{{ page.TODO }}
-{:.dev-settings .alert .alert-warning}
+{{ page.TODO }} {:.dev-settings .alert .alert-warning}
 
 ## Introduction
 
-This is where we begin our journey. The place where we return after getting lost or wandering off.
-Think of this as our home base with a collection of maps, tools, and information we need to traverse through this chaotic digital world.
-There are [journals](/posts) to capture our experiences and findings, [notes](/notes) to quickly reference when our memories fail, and a [library](/docs) of documentation that gives us the depth of knowledge to build upon and share.
-Everything here is open source and free to use, and the goal is to make this repository a comprehensive learning tool for everyone to use and share.
+This is where we begin our journey. The place where we return after getting lost or wandering off. Think of this as our home base with a collection of maps, tools, and information we need to traverse through this chaotic digital world. There are [journals](/posts) to capture our experiences and findings, [notes](/notes) to quickly reference when our memories fail, and a [library](/docs) of documentation that gives us the depth of knowledge to build upon and share. Everything here is open source and free to use, and the goal is to make this repository a comprehensive learning tool for everyone to use and share.
 
 ## Abstract
 
@@ -81,8 +77,7 @@ For those who are intermediate/advanced and want to work on a specific stack:
 5. Infrastructure (AWS, Azure, GCP, Linux)
 6. Solutions (LAMP, Jamstack, MERN, WINS)
 
-[Source](https://devopedia.org/full-stack-developer)
-[Wiki](https://en.wikipedia.org/wiki/Solution_stack)
+[Source](https://devopedia.org/full-stack-developer) [Wiki](https://en.wikipedia.org/wiki/Solution_stack)
 
 ### Specialization route
 
@@ -168,5 +163,4 @@ local_git_pc             : [ *home-win, 'github\' ]
 local_git_mac            : [ *home-mac, 'GitHub/' ]
 ```
 
-NOTE: Replace `$HOME` with your home directory. Normally, it is the user id of the machine. Just type `echo $HOME` in the terminal.
-{: .alert .alert-primary }
+NOTE: Replace `$HOME` with your home directory. Normally, it is the user id of the machine. Just type `echo $HOME` in the terminal. {: .alert .alert-primary }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,13 +1,10 @@
 # Site generation scripts
 
-This folder holds the data-driven generators for the site. Both follow the same pattern:
-a small curated source + live GitHub metadata → committed, deterministic Markdown.
+This folder holds the data-driven generators for the site. Both follow the same pattern: a small curated source + live GitHub metadata → committed, deterministic Markdown.
 
 ## `generate_portfolio.py` — profile / portfolio landing page
 
-Reads the curated registry `_data/projects.yml`, fetches live metadata for each repo from the
-GitHub API (stars, language, homepage / GitHub Pages URL, topics, license, last commit), and
-renders two surfaces:
+Reads the curated registry `_data/projects.yml`, fetches live metadata for each repo from the GitHub API (stars, language, homepage / GitHub Pages URL, topics, license, last commit), and renders two surfaces:
 
 - `pages/_about/portfolio/index.md` — the full showcase, grouped by category.
 - the `<!-- AUTO:portfolio:start -->…<!-- AUTO:portfolio:end -->` span in `README.md` — the
@@ -19,17 +16,11 @@ python3 scripts/generate_portfolio.py --check    # CI drift gate: exit 1 if outp
 python3 scripts/generate_portfolio.py --owner bamr87 --token "$GH_TOKEN"
 ```
 
-To add / reorder / feature a project, edit `_data/projects.yml` (display order = file order) and
-rerun — do not hand-edit the generated files. A token resolves from `--token`, then
-`FEATURES_GITHUB_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`, then `gh auth token`; public repos work without
-one but share a low rate limit. Output is timestamp-stable, so a no-op rerun produces no diff.
-See `.claude/skills/profile-portfolio/SKILL.md` for the full workflow.
+To add / reorder / feature a project, edit `_data/projects.yml` (display order = file order) and rerun — do not hand-edit the generated files. A token resolves from `--token`, then `FEATURES_GITHUB_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`, then `gh auth token`; public repos work without one but share a low rate limit. Output is timestamp-stable, so a no-op rerun produces no diff. See `.claude/skills/profile-portfolio/SKILL.md` for the full workflow.
 
 ## `generate_features_index.py` — consolidated features index
 
-This script scans sibling repos in the workspace (local mode) or fetches feature metadata
-from GitHub (remote mode) and generates `pages/_about/features/index.md` that consolidates
-features across all repositories.
+This script scans sibling repos in the workspace (local mode) or fetches feature metadata from GitHub (remote mode) and generates `pages/_about/features/index.md` that consolidates features across all repositories.
 
 Supported metadata sources (per repo):
 
@@ -68,8 +59,7 @@ Running remotely (GitHub API):
 FEATURES_GITHUB_TOKEN=$GH_TOKEN python3 scripts/generate_features_index.py --mode=remote --owner=bamr87
 ```
 
-The script writes to `pages/_about/features/index.md` by default — make sure the repository has
-commit access if you plan to have a scheduled GitHub Action commit updates automatically.
+The script writes to `pages/_about/features/index.md` by default — make sure the repository has commit access if you plan to have a scheduled GitHub Action commit updates automatically.
 
 Automation idea:
 
@@ -79,10 +69,6 @@ Automation idea:
 - Each repo should adopt a short `features/features.yml` file to declare features — see sample
   `examples` directory.
 
-If you'd like, the script can be extended to fetch additional context (issues, PRs, changelog,
-release tags) or render richer tables, badges and links.
+If you'd like, the script can be extended to fetch additional context (issues, PRs, changelog, release tags) or render richer tables, badges and links.
 
-Validator:
-  A minimal validator is available at `scripts/validate_features.py`. Repositories can add a
-  workflow to run this file during PRs to ensure they publish and maintain good `features` metadata
-  before changes are merged.
+Validator: A minimal validator is available at `scripts/validate_features.py`. Repositories can add a workflow to run this file during PRs to ensure they publish and maintain good `features` metadata before changes are merged.

--- a/tools/unwrap-prose.py
+++ b/tools/unwrap-prose.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+unwrap-prose.py — join soft-wrapped prose lines so each paragraph is one line.
+
+Only body-text paragraphs are unwrapped. Everything structural is left
+byte-for-byte identical: YAML/TOML front matter, fenced & indented code,
+tables (any line containing "|"), lists, blockquotes, ATX & setext headings,
+block-level HTML, Liquid "{% %}" tag lines, reference/footnote definitions,
+thematic breaks, and any paragraph that uses hard line breaks (a line ending
+in two+ spaces or a backslash).
+
+Conservative by design: when a line's role is ambiguous it is treated as a
+boundary and left alone rather than risk corrupting structure. The transform
+is idempotent — running it twice yields the same result as running it once.
+
+Usage:
+  unwrap-prose.py --check [PATHS ...]   # list files that WOULD change; exit 1 if any
+  unwrap-prose.py --diff  [PATHS ...]   # print a unified diff; no writes
+  unwrap-prose.py --write [PATHS ...]   # rewrite files in place
+
+With no PATHS, operates on the current repo's git-tracked *.md / *.markdown
+files (so vendored/ignored/submodule content is excluded automatically).
+"""
+# Vendored verbatim from the bamr87 hub (tools/unwrap-prose.py) into each repo
+# by tools/fanout.sh; it is not the host repo's own source, so it opts out of
+# that repo's linters / type-checkers rather than chase every project's config.
+# ruff: noqa
+# flake8: noqa
+# mypy: ignore-errors
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --- line classifiers -------------------------------------------------------
+BLANK = re.compile(r"^\s*$")
+FRONT_FENCE = re.compile(r"^(---|\+\+\+)\s*$")          # YAML/TOML front matter delimiter
+FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")            # ``` or ~~~ code fence
+ATX = re.compile(r"^\s{0,3}#{1,6}(\s|$)")               # # Heading
+LIST = re.compile(r"^\s{0,3}([-*+]|\d+[.)])\s")         # -, *, +, 1. list item
+QUOTE = re.compile(r"^\s{0,3}>")                        # > blockquote
+HTML = re.compile(r"^\s{0,3}<")                          # block-level HTML / autolink
+LIQUID = re.compile(r"^\s*\{%")                          # {% if %}, {% for %}, {% include %}
+REF_DEF = re.compile(r"^\s{0,3}\[[^\]]+\]:\s")          # [id]: https://...
+FOOTNOTE = re.compile(r"^\s{0,3}\[\^[^\]]+\]:")         # [^n]: ...
+HR = re.compile(r"^\s{0,3}([-*_])(\s*\1){2,}\s*$")      # ---, ***, ___ thematic break
+INDENT_CODE = re.compile(r"^(\t| {4,})")                # 4-space / tab indented code
+SETEXT = re.compile(r"^\s{0,3}(=+|-+)\s*$")             # === or --- heading underline
+HARD_BREAK = re.compile(r"(\s{2,}|\\)$")                # trailing "  " or "\" -> <br>
+
+
+def starts_atomic(line: str) -> bool:
+    """A line that must never be merged into a prose paragraph."""
+    return bool(
+        ATX.match(line)
+        or LIST.match(line)
+        or QUOTE.match(line)
+        or HTML.match(line)
+        or LIQUID.match(line)
+        or REF_DEF.match(line)
+        or FOOTNOTE.match(line)
+        or HR.match(line)
+        or INDENT_CODE.match(line)
+        or FENCE.match(line)
+        or "|" in line  # any table row (leading-pipe or not) — safe to leave alone
+    )
+
+
+def transform(text: str) -> str:
+    had_final_nl = text.endswith("\n")
+    lines = text.splitlines()
+    out: list[str] = []
+    i, n = 0, len(lines)
+
+    # Front matter: only when the very first line is exactly --- or +++.
+    if n and FRONT_FENCE.match(lines[0]):
+        out.append(lines[0])
+        i = 1
+        while i < n:
+            out.append(lines[i])
+            closed = FRONT_FENCE.match(lines[i])
+            i += 1
+            if closed:
+                break
+
+    while i < n:
+        line = lines[i]
+
+        # Fenced code block: copy verbatim through the matching closing fence.
+        m = FENCE.match(line)
+        if m:
+            ticks = m.group(1)
+            fence_char, fence_len = ticks[0], len(ticks)
+            out.append(line)
+            i += 1
+            while i < n:
+                out.append(lines[i])
+                c = FENCE.match(lines[i])
+                i += 1
+                if c and c.group(1)[0] == fence_char and len(c.group(1)) >= fence_len:
+                    break
+            continue
+
+        if BLANK.match(line) or starts_atomic(line):
+            out.append(line)
+            i += 1
+            continue
+
+        # A prose paragraph: gather its wrapped continuation lines.
+        group = [line]
+        i += 1
+        while i < n:
+            nxt = lines[i]
+            if BLANK.match(nxt) or starts_atomic(nxt) or SETEXT.match(nxt):
+                break
+            if HARD_BREAK.search(group[-1]):          # previous line forces a break
+                break
+            if i + 1 < n and SETEXT.match(lines[i + 1]):  # nxt is a setext heading's text
+                break
+            group.append(nxt)
+            i += 1
+
+        # A paragraph that uses hard breaks keeps its author-chosen line layout.
+        if len(group) == 1 or any(HARD_BREAK.search(g) for g in group):
+            out.extend(group)
+        else:
+            out.append(" ".join(g.strip() for g in group))
+
+    result = "\n".join(out)
+    if had_final_nl:
+        result += "\n"
+    return result
+
+
+# --- driver -----------------------------------------------------------------
+def git_tracked_md() -> list[Path]:
+    try:
+        raw = subprocess.check_output(
+            ["git", "ls-files", "-z", "*.md", "*.markdown"], text=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [Path(p) for p in raw.split("\0") if p]
+
+
+def iter_paths(paths: list[str]) -> list[Path]:
+    if not paths:
+        return git_tracked_md()
+    found: list[Path] = []
+    for p in paths:
+        pp = Path(p)
+        if pp.is_dir():
+            found += sorted(pp.rglob("*.md")) + sorted(pp.rglob("*.markdown"))
+        else:
+            found.append(pp)
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Unwrap soft-wrapped markdown prose.")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="list files that would change; exit 1 if any")
+    mode.add_argument("--diff", action="store_true", help="print a unified diff; no writes")
+    mode.add_argument("--write", action="store_true", help="rewrite files in place")
+    ap.add_argument("--exclude", action="append", metavar="REGEX", default=[],
+                    help="skip paths matching this regex (repeatable)")
+    ap.add_argument("paths", nargs="*", help="files/dirs (default: git-tracked markdown)")
+    args = ap.parse_args()
+
+    excludes = [re.compile(p) for p in args.exclude]
+    changed: list[Path] = []
+    for path in iter_paths(args.paths):
+        if any(rx.search(path.as_posix()) for rx in excludes):
+            continue
+        try:
+            original = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            print(f"skip {path}: {e}", file=sys.stderr)
+            continue
+        updated = transform(original)
+        if updated == original:
+            continue
+        changed.append(path)
+        if args.diff:
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    updated.splitlines(keepends=True),
+                    fromfile=str(path),
+                    tofile=str(path),
+                )
+            )
+        elif args.write:
+            path.write_text(updated, encoding="utf-8")
+            print(f"unwrapped {path}")
+        else:  # --check (default)
+            print(path)
+
+    if args.check or not (args.diff or args.write):
+        if changed:
+            print(f"\n{len(changed)} file(s) would change.", file=sys.stderr)
+            return 1
+        print("All markdown prose already unwrapped.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Automated by bamr87 prose-fanout (tools/fanout.sh): unwraps soft-wrapped markdown prose so each paragraph is a single line — Liquid/HTML/tables/code/front-matter left byte-for-byte, and SCHEMA.md/CHANGELOG.md skipped. Also vendors tools/unwrap-prose.py and seeds a markdown-oneline CI check. Additive-only. See bamr87/bamr87.