### PR TITLE
docs: correct portfolio pipeline docs (three outputs, /profile/ move, live_url)

### DIFF
--- a/.claude/skills/profile-portfolio/SKILL.md
+++ b/.claude/skills/profile-portfolio/SKILL.md
@@ -14,16 +14,17 @@ description: >-
 
 # Profile / Portfolio landing page
 
-This site (`bamr87.github.io`) is the user's profile + portfolio landing page. The showcase of their GitHub work is **data-driven**: a curated registry plus live GitHub metadata, rendered into two surfaces by one generator. Editing the rendered output by hand is a dead end — it gets overwritten on the next run. Always change the source and regenerate.
+This site (`bamr87.github.io`) is the user's profile + portfolio landing page. The showcase of their GitHub work is **data-driven**: a curated registry plus live GitHub metadata, rendered into three surfaces by one generator. Editing the rendered output by hand is a dead end — it gets overwritten on the next run. Always change the source and regenerate.
 
 ## The pipeline at a glance
 
 ```
-_data/projects.yml   →   scripts/generate_portfolio.py   →   pages/_about/portfolio/index.md   (full showcase page)
-(curated registry)       (fetches live GitHub metadata)  →   README.md  AUTO:portfolio span     (featured table on homepage)
+_data/projects.yml   →   scripts/generate_portfolio.py   →   _data/portfolio.yml                (enriched data + totals — homepage dashboard)
+(curated registry)       (fetches live GitHub metadata)  →   pages/_about/portfolio/index.md    (full showcase page)
+                                                         →   README.md  AUTO:portfolio span     (featured table on the GitHub profile)
 ```
 
-`README.md` is the site homepage (`permalink: /`), so the featured table appears on the landing page; the full grouped showcase lives at `/about/portfolio/`.
+The site homepage is `index.html` at `/` (`layout: home`) — a showcase/dashboard that renders from `_data/portfolio.yml` via `site.data.portfolio`. `README.md` is the GitHub profile/CV and renders on the site at `/profile/` — it is **no longer the homepage**. The full grouped showcase lives at `/about/portfolio/`.
 
 This is the sibling of `scripts/generate_features_index.py` (which aggregates *feature* metadata across repos). Same philosophy: a registry + the GitHub API + deterministic, committable output.
 
@@ -37,18 +38,21 @@ exclude:                 # repos that must never appear (clones, scratch, WIP)
   - some-clone
 projects:
   - repo: it-journey     # required — the repo name under `owner`
-    featured: true       # optional — show in homepage table + "Featured" section
+    featured: true       # optional — homepage featured cards + portfolio "Featured" section + README table
     category: "Apps & AI" # optional — grouping heading on the portfolio page (default "Projects")
     blurb: "..."         # optional — overrides the GitHub description when it's weak/empty
+    live_url: false      # optional — override the auto Live link: false/none suppresses, a URL string repoints
 ```
 
 Only `repo` is required. Everything else (stars, language, homepage/Pages URL, topics, license, last commit) is fetched live from GitHub at generation time, so the registry stays small and the page stays current without manual edits.
 
 ## Common tasks
 
-**Add or feature a project** — append (or move) an entry in `_data/projects.yml`, set `featured:`/`category:`/`blurb:` as desired, then regenerate. Put featured projects where you want them in the homepage table; order matters.
+**Add or feature a project** — append (or move) an entry in `_data/projects.yml`, set `featured:`/`category:`/`blurb:` as desired, then regenerate. Put featured projects where you want them; registry order drives the homepage cards and README table alike.
 
 **Remove a project from the showcase** — delete its entry, or add it to `exclude:` if it keeps reappearing from some auto-source.
+
+**Repoint or hide a Live link** — set `live_url:` on the entry: a URL string replaces the auto-derived homepage/GitHub Pages link; `false`/`none` suppresses the Live link entirely (e.g. a dead custom domain). Key absent = auto-derive. Then regenerate.
 
 **Refresh metadata** (stars/descriptions/links changed upstream) — just rerun the generator; no registry edit needed.
 
@@ -62,8 +66,8 @@ The generator resolves a GitHub token from `--token`, then `FEATURES_GITHUB_TOKE
 
 ## Conventions to preserve
 
-- **Don't hand-edit** `pages/_about/portfolio/index.md` or the
-`<!-- AUTO:portfolio:start -->…<!-- AUTO:portfolio:end -->` span in `README.md`. Both carry a "generated — edit the registry instead" banner. Change `_data/projects.yml` and regenerate.
+- **Don't hand-edit** `_data/portfolio.yml`, `pages/_about/portfolio/index.md`, or the
+`<!-- AUTO:portfolio:start -->…<!-- AUTO:portfolio:end -->` span in `README.md`. All three carry a "generated — edit the registry instead" banner. Change `_data/projects.yml` and regenerate.
 - A repo that fails to fetch (network off, renamed, private) renders from registry
   data alone and logs a warning — fix the `repo:` name if you see a 404 warning.
 - After regenerating, review the diff, then commit registry + generated files
@@ -73,4 +77,4 @@ The generator resolves a GitHub token from `--token`, then `FEATURES_GITHUB_TOKE
 
 ## Why this design
 
-The user wants the site to be the definitive, low-maintenance showcase of their work. A hand-maintained project list rots — stars go stale, links break, new repos never get added. By curating *intent* (which repos, in what order, how described) in a tiny YAML file and pulling *facts* (stars, language, live URL) from GitHub on every build, the page stays accurate with near-zero upkeep, and the homepage + portfolio page can never disagree because one generator writes both.
+The user wants the site to be the definitive, low-maintenance showcase of their work. A hand-maintained project list rots — stars go stale, links break, new repos never get added. By curating *intent* (which repos, in what order, how described) in a tiny YAML file and pulling *facts* (stars, language, live URL) from GitHub on every build, the page stays accurate with near-zero upkeep, and the homepage dashboard, portfolio page, and profile README can never disagree because one generator writes all three.

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,14 +1,16 @@
 # Portfolio registry — the single source of truth for the profile/portfolio
 # landing page. `scripts/generate_portfolio.py` reads this file, fetches live
 # metadata from GitHub (stars, language, homepage, GitHub Pages URL, topics),
-# and renders pages/_about/portfolio/index.md plus the featured block in README.md.
+# and renders _data/portfolio.yml (homepage dashboard data), pages/_about/portfolio/index.md,
+# and the featured block in README.md (the GitHub profile, served at /profile/).
 #
 # To add or reorder a project: edit this file and rerun the generator. Display
 # order follows the order here. Per-project fields:
 #   repo:      (required) the GitHub repo name under `owner`
-#   featured:  show in the homepage table + the "Featured" section (default false)
+#   featured:  show in the homepage cards, the "Featured" section + README table (default false)
 #   category:  grouping heading on the portfolio page (default "Projects")
 #   blurb:     overrides the GitHub description when the upstream one is weak/empty
+#   live_url:  override the auto Live link (false/none suppresses, a URL string repoints)
 
 owner: bamr87
 

--- a/scripts/generate_portfolio.py
+++ b/scripts/generate_portfolio.py
@@ -7,8 +7,11 @@ It reads a curated registry (`_data/projects.yml`), fetches live metadata for ea
 repo from the GitHub API (description, stars, language, homepage, GitHub Pages URL,
 topics, license, last push), merges the two, and renders:
 
-  1. A full showcase page  -> pages/_about/portfolio/index.md
-  2. A featured subset      -> the AUTO:portfolio span inside README.md (the homepage)
+  1. Enriched data + totals -> _data/portfolio.yml (the homepage dashboard at /
+     renders it via site.data.portfolio)
+  2. A full showcase page   -> pages/_about/portfolio/index.md
+  3. A featured subset      -> the AUTO:portfolio span inside README.md (the
+     GitHub profile/CV, rendered on the site at /profile/)
 
 This is the sibling of `generate_features_index.py`: same urllib + optional-token
 approach so it runs unchanged in CI, but it falls back to `gh auth token` locally.
@@ -240,7 +243,7 @@ def render_portfolio_page(projects: List[dict], now: str) -> str:
 
 
 def render_readme_block(projects: List[dict]) -> str:
-    """A compact featured table for the README homepage."""
+    """A compact featured table for the README (GitHub profile, /profile/)."""
     featured = [p for p in projects if p['featured']]
     rows = ["| Project | Description | Links |", "|---|---|---|"]
     for p in featured:


### PR DESCRIPTION
The profile-portfolio skill, the generator docstrings, and the _data/projects.yml header all still claimed README.md is the homepage and named only two generator outputs. Corrected everywhere: index.html renders / from _data/portfolio.yml (README renders at /profile/), the generator writes three surfaces, and the live_url override is now documented. py_compile-verified.

Part of the fleet-wide .claude standardization pass (hub: bamr87/bamr87#73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)